### PR TITLE
feat: add Microsoft Outlook mailbox register support

### DIFF
--- a/build_pkce_probe.py
+++ b/build_pkce_probe.py
@@ -1,0 +1,180 @@
+"""Run one interactive xAI Build Authorization Code + PKCE probe."""
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import secrets
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from curl_cffi import requests
+
+from cpa_xai.schema import build_cpa_xai_auth, jwt_payload
+from cpa_xai.writer import write_cpa_xai_auth
+
+
+CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+AUTHORIZE_URL = "https://auth.x.ai/oauth2/authorize"
+TOKEN_URL = "https://auth.x.ai/oauth2/token"
+REDIRECT_URI = "http://127.0.0.1:56121/callback"
+SCOPE = (
+    "openid profile email offline_access grok-cli:access api:access "
+    "conversations:read conversations:write"
+)
+
+
+def _b64url(value):
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def build_authorize_url(state, nonce, challenge):
+    return AUTHORIZE_URL + "?" + urlencode({
+        "response_type": "code",
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPE,
+        "state": state,
+        "nonce": nonce,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "plan": "generic",
+        "referrer": "grok-build",
+    })
+
+
+class CallbackState:
+    def __init__(self):
+        self.event = threading.Event()
+        self.params = {}
+
+
+def make_handler(callback_state):
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path != "/callback":
+                self.send_response(404)
+                self.end_headers()
+                return
+            callback_state.params = {
+                key: values[0] if values else ""
+                for key, values in parse_qs(parsed.query).items()
+            }
+            callback_state.event.set()
+            body = "xAI Build authorization received. You can return to Codex."
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body.encode("utf-8"))))
+            self.end_headers()
+            self.wfile.write(body.encode("utf-8"))
+
+        def log_message(self, _format, *_args):
+            return
+
+    return CallbackHandler
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="config.json")
+    parser.add_argument("--timeout", type=int, default=300)
+    args = parser.parse_args()
+
+    config = json.loads(Path(args.config).read_text(encoding="utf-8"))
+    proxy = str(config.get("proxy", "") or "").strip()
+    auth_dir = str(config.get("cpa_auth_dir", "./cpa_auths") or "./cpa_auths")
+    base_url = str(config.get("cpa_base_url", "") or "").strip()
+
+    verifier = _b64url(secrets.token_bytes(32))
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    state = secrets.token_hex(32)
+    nonce = secrets.token_hex(16)
+    callback_state = CallbackState()
+    server = HTTPServer(("127.0.0.1", 56121), make_handler(callback_state))
+    server.timeout = 0.5
+
+    def serve_until_callback():
+        deadline = time.time() + args.timeout
+        while not callback_state.event.is_set() and time.time() < deadline:
+            server.handle_request()
+
+    thread = threading.Thread(target=serve_until_callback, daemon=True)
+    thread.start()
+    print("AUTH_URL=" + build_authorize_url(state, nonce, challenge), flush=True)
+
+    thread.join(args.timeout + 2)
+    server.server_close()
+    if not callback_state.event.is_set():
+        print("PKCE_OK=False", flush=True)
+        print("PKCE_REASON=callback_timeout", flush=True)
+        return 2
+
+    params = callback_state.params
+    if params.get("state") != state:
+        print("PKCE_OK=False", flush=True)
+        print("PKCE_REASON=state_mismatch", flush=True)
+        return 3
+    if params.get("error"):
+        print("PKCE_OK=False", flush=True)
+        print("PKCE_REASON=" + str(params.get("error")), flush=True)
+        return 4
+    code = str(params.get("code", "") or "").strip()
+    if not code:
+        print("PKCE_OK=False", flush=True)
+        print("PKCE_REASON=missing_code", flush=True)
+        return 5
+
+    request_options = {"timeout": 30, "impersonate": "chrome"}
+    if proxy:
+        request_options["proxies"] = {"http": proxy, "https": proxy}
+    response = requests.post(TOKEN_URL, data={
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": REDIRECT_URI,
+        "client_id": CLIENT_ID,
+        "code_verifier": verifier,
+    }, headers={
+        "Accept": "*/*",
+        "User-Agent": "grok-pager/0.2.93 grok-shell/0.2.93 (windows; x86_64)",
+        "X-Grok-Client-Version": "0.2.93",
+    }, **request_options)
+    if response.status_code != 200:
+        print("PKCE_OK=False", flush=True)
+        print("PKCE_REASON=token_http_" + str(response.status_code), flush=True)
+        return 6
+
+    tokens = response.json()
+    access_token = str(tokens.get("access_token", "") or "")
+    refresh_token = str(tokens.get("refresh_token", "") or "")
+    claims = jwt_payload(access_token) if access_token else {}
+    referrer = str(claims.get("referrer", "") or "")
+    email = str(claims.get("email", "") or "")
+    ok = bool(access_token and refresh_token and referrer == "grok-build")
+    print("PKCE_OK=" + str(ok), flush=True)
+    print("PKCE_HAS_REFRESH=" + str(bool(refresh_token)), flush=True)
+    print("PKCE_REFERRER_OK=" + str(referrer == "grok-build"), flush=True)
+    if not ok:
+        return 7
+
+    payload = build_cpa_xai_auth(
+        email=email,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        id_token=tokens.get("id_token"),
+        expires_in=tokens.get("expires_in"),
+        base_url=base_url,
+        token_endpoint=TOKEN_URL,
+        redirect_uri=REDIRECT_URI,
+    )
+    destination = write_cpa_xai_auth(auth_dir, payload)
+    print("PKCE_SAVED=" + str(bool(destination and os.path.exists(destination))), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cpa_xai/browser_confirm.py
+++ b/cpa_xai/browser_confirm.py
@@ -154,14 +154,22 @@ def _norm(text: str) -> str:
 
 
 def _find_button_exact(page: Any, label: str) -> Optional[Any]:
-    try:
-        return page.ele(
-            "xpath://button[normalize-space()='%s'] | //*[@role='button' and normalize-space()='%s'] | //a[normalize-space()='%s'] | //input[@type='submit' and @value='%s']"
-            % (label, label, label, label),
-            timeout=0.4,
-        )
-    except Exception:
-        return None
+    # 页面动态渲染时元素可能刚挂载但尚未可见/无几何尺寸：加大超时并重试，
+    # 避免真实点击时出现"该元素没有位置及大小"。
+    for attempt in range(3):
+        try:
+            target = page.ele(
+                "xpath://button[normalize-space()='%s'] | //*[@role='button' and normalize-space()='%s'] | //a[normalize-space()='%s'] | //input[@type='submit' and @value='%s']"
+                % (label, label, label, label),
+                timeout=2.0,
+            )
+            if target:
+                return target
+        except Exception:
+            pass
+        if attempt < 2:
+            time.sleep(0.5)
+    return None
 
 
 def _cookie_banner_visible(text: str) -> bool:
@@ -199,7 +207,11 @@ def _click_exact(page: Any, labels, log: LogFn, real: bool = False) -> Optional[
             continue
         try:
             if real:
-                target.click()
+                try:
+                    target.click()
+                except Exception:
+                    # 真实点击失败（元素不可见/未渲染完）时兜底 JS 点击
+                    target.click(by_js=True)
             else:
                 try:
                     target.click(by_js=True)
@@ -216,20 +228,29 @@ def _wait_turnstile(page: Any, log: LogFn, timeout_sec: float, email: str = "", 
     deadline = time.time() + float(timeout_sec)
     while time.time() < deadline:
         text = _visible_text(page)
-        if not _is_turnstile_challenge(text):
-            try:
-                token_length = page.run_js(
-                    """
-                    const input = document.querySelector('input[name="cf-turnstile-response"]');
-                    return String((input && input.value) || '').trim().length;
-                    """
-                )
-                if int(token_length or 0) >= 80:
-                    return True
-            except Exception:
-                pass
-            if not _is_turnstile_challenge(_visible_text(page)):
+        try:
+            state = page.run_js(
+                """
+                const input = document.querySelector('input[name="cf-turnstile-response"]');
+                const present = !!input
+                  || !!document.querySelector(
+                    'iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey], script[src*="turnstile"]'
+                  );
+                return {
+                  present,
+                  tokenLength: String((input && input.value) || '').trim().length,
+                };
+                """
+            )
+        except Exception:
+            state = None
+        if isinstance(state, dict):
+            if int(state.get("tokenLength") or 0) >= 80:
                 return True
+            if not bool(state.get("present")) and not _is_turnstile_challenge(text):
+                return True
+        elif not _is_turnstile_challenge(text):
+            return True
         _sleep(1.0)
     if raise_on_timeout:
         shot = _save_debug_shot(page, tag="turnstile-timeout", email=email, log=log)
@@ -241,8 +262,56 @@ def _wait_turnstile(page: Any, log: LogFn, timeout_sec: float, email: str = "", 
 
 
 def _fill(page: Any, selector: str, value: str, log: LogFn, label: str = "") -> bool:
+    expected = str(value or "")
+    dom_selector = selector[4:] if selector.startswith("css:") else selector
+    marker = "cpa-active-input"
     try:
-        target = page.ele(selector, timeout=0.8)
+        state = page.run_js(
+            """
+            const selector = arguments[0];
+            const value = String(arguments[1] || '');
+            const marker = arguments[2];
+            function isVisible(node) {
+              if (!node || node.disabled) return false;
+              const style = window.getComputedStyle(node);
+              if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') return false;
+              const rect = node.getBoundingClientRect();
+              return rect.width > 0 && rect.height > 0;
+            }
+            const candidates = Array.from(document.querySelectorAll(selector)).filter(isVisible);
+            const matching = candidates.find((node) => String(node.value || '') === value);
+            if (matching && matching.readOnly) {
+              return { status: 'readonly-match', value: String(matching.value || '') };
+            }
+            const node = candidates.find((candidate) => !candidate.readOnly);
+            if (!node) {
+              const readonly = candidates.find((candidate) => candidate.readOnly);
+              return {
+                status: readonly ? 'readonly-mismatch' : 'not-found',
+                value: String((readonly && readonly.value) || ''),
+              };
+            }
+            for (const previous of document.querySelectorAll('[data-cpa-fill-target]')) {
+              previous.removeAttribute('data-cpa-fill-target');
+            }
+            node.setAttribute('data-cpa-fill-target', marker);
+            return { status: 'editable', value: String(node.value || '') };
+            """,
+            dom_selector,
+            expected,
+            marker,
+        )
+    except Exception:
+        state = None
+    if isinstance(state, dict) and state.get("status") == "readonly-match":
+        if label:
+            log("filled %s" % label)
+        return True
+    if not isinstance(state, dict) or state.get("status") != "editable":
+        return False
+
+    try:
+        target = page.ele('css:[data-cpa-fill-target="%s"]' % marker, timeout=0.8)
     except Exception:
         target = None
     if not target:
@@ -258,22 +327,48 @@ def _fill(page: Any, selector: str, value: str, log: LogFn, label: str = "") -> 
             target.click()
             page.run_js(
                 """
-                const selector = arguments[0];
-                const value = arguments[1];
-                const node = document.querySelector(selector);
+                const marker = arguments[0];
+                const value = String(arguments[1] || '');
+                const node = document.querySelector('[data-cpa-fill-target="' + marker + '"]');
                 if (!node) return false;
+                const oldValue = String(node.value || '');
                 const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
                 if (setter) setter.call(node, value);
                 else node.value = value;
+                if (node._valueTracker) node._valueTracker.setValue(oldValue);
                 node.dispatchEvent(new Event('input', { bubbles: true }));
                 node.dispatchEvent(new Event('change', { bubbles: true }));
                 return true;
                 """,
-                selector,
-                value,
+                marker,
+                expected,
             )
         except Exception:
             return False
+    try:
+        actual = page.run_js(
+            """
+            const node = document.querySelector('[data-cpa-fill-target="' + arguments[0] + '"]');
+            return String((node && node.value) || '');
+            """,
+            marker,
+        )
+        actual = str(actual or "")
+        if actual != expected:
+            return False
+    except Exception:
+        return False
+    finally:
+        try:
+            page.run_js(
+                """
+                const node = document.querySelector('[data-cpa-fill-target="' + arguments[0] + '"]');
+                if (node) node.removeAttribute('data-cpa-fill-target');
+                """,
+                marker,
+            )
+        except Exception:
+            pass
     if label:
         log("filled %s" % label)
     return True
@@ -294,6 +389,9 @@ def _detect_auth_error(text: str, url: str = "") -> Optional[str]:
         ("密码错误", "wrong password"),
         ("wrong email", "wrong email"),
         ("invalid email", "wrong email"),
+        ("必须提供一个邮箱地址", "email address was cleared before submit"),
+        ("email address is required", "email address was cleared before submit"),
+        ("email is required", "email address was cleared before submit"),
         ("attention required", "cloudflare challenge/block"),
         ("access denied", "cloudflare blocked / access denied"),
         ("unable to access", "cloudflare blocked / unable to access"),
@@ -464,11 +562,29 @@ def approve_device_code(
             if login_attempts >= 3:
                 auth_error = _detect_auth_error(text, url) or "login failed after retries (still on password page)"
                 raise BrowserConfirmError("auth failed: %s" % auth_error)
+            if page.ele("css:input[type='email']", timeout=0.2):
+                if not _fill(page, "css:input[type='email']", email, logger, "email"):
+                    _sleep(0.5)
+                    continue
+            if not _fill(page, "css:input[type='password']", password, logger, "password"):
+                _sleep(0.5)
+                continue
+            turnstile_timeout = max(min(deadline - time.time(), 180.0), 1.0)
+            logger("waiting for Cloudflare verification in browser (up to %ss)" % int(turnstile_timeout))
+            if not _wait_turnstile(page, logger, turnstile_timeout, email=email, raise_on_timeout=False):
+                shot = _save_debug_shot(page, tag="turnstile-timeout", email=email, log=logger)
+                message = "turnstile timeout before login submit"
+                if shot:
+                    message = "%s shot=%s" % (message, shot)
+                raise BrowserConfirmError("auth failed: %s" % message)
+            if page.ele("css:input[type='email']", timeout=0.2):
+                if not _fill(page, "css:input[type='email']", email, logger, "email"):
+                    _sleep(0.5)
+                    continue
+            if not _fill(page, "css:input[type='password']", password, logger, "password"):
+                _sleep(0.5)
+                continue
             login_attempts += 1
-            _fill(page, "css:input[type='email']", email, logger, "email")
-            _wait_turnstile(page, logger, 25, email=email, raise_on_timeout=True)
-            _fill(page, "css:input[type='password']", password, logger, "password")
-            _wait_turnstile(page, logger, 12, email=email, raise_on_timeout=False)
             if not _click_exact(page, ["登录", "Sign in", "Log in"], logger, real=True):
                 try:
                     submit = page.ele("css:button[type='submit']", timeout=0.5) or page.ele("css:button[data-testid='sign-in-submit']", timeout=0.5)

--- a/mail_service.py
+++ b/mail_service.py
@@ -1,11 +1,15 @@
 """接入临时邮箱服务并负责邮箱创建、邮件轮询和验证码提取。"""
+import json
+import os
 import re
 import secrets
 import string
+import subprocess
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from curl_cffi import requests
+from filelock import FileLock
 
 DUCKMAIL_API_BASE = "https://api.duckmail.sbs"
 
@@ -16,6 +20,12 @@ config = {}
 _cf_domain_index = 0
 _cloudmail_domain_index = 0
 _OWN_NAMES = {'cloudmail_get_email_and_token', 'get_messages', 'cloudflare_get_messages', 'get_yyds_api_key', 'yyds_generate_username', 'yyds_get_domains', 'yyds_get_email_and_token', 'yyds_get_oai_code', 'get_email_provider', 'cloudflare_get_domains', 'extract_verification_code', 'get_cloudflare_api_base', 'cloudflare_apply_auth_params', 'duckmail_get_oai_code', 'create_account', 'get_yyds_jwt', 'get_message_detail', 'yyds_create_account', 'get_duckmail_api_key', 'get_cloudflare_path', 'cloudflare_create_account', 'cloudflare_get_token', 'cloudflare_get_oai_code', 'get_cloudmail_public_token', 'generate_username', 'yyds_get_message_detail', 'cloudflare_next_default_domain', 'yyds_get_messages', 'yyds_get_token', 'get_domains', 'get_token', 'cloudflare_create_temp_address', 'get_cloudflare_api_key', 'get_cloudmail_path', 'get_cloudmail_api_base', 'cloudmail_get_oai_code', 'cloudflare_build_headers', 'cloudflare_is_admin_create_path', 'cloudmail_next_domain', 'cloudflare_get_message_detail', 'cloudmail_get_messages', 'get_user_agent', 'yyds_pick_domain', '_pick_list_payload', 'get_email_and_token', 'get_oai_code', 'get_cloudflare_auth_mode', 'pick_domain'}
+_OWN_NAMES.update({
+    "get_outlook_register_dir",
+    "outlook_web_get_email_and_token",
+    "outlook_web_get_oai_code",
+    "outlook_web_update_status",
+})
 
 
 def bind_runtime(namespace):
@@ -544,6 +554,202 @@ def get_cloudmail_path():
 def get_cloudmail_public_token():
     return str(config.get("cloudmail_public_token", "") or "").strip()
 
+
+def get_outlook_register_dir():
+    return os.path.abspath(
+        os.path.expanduser(str(config.get("outlook_register_dir", "") or "").strip())
+    )
+
+
+def _outlook_web_paths():
+    base_dir = get_outlook_register_dir()
+    return {
+        "base_dir": base_dir,
+        "pool_file": os.path.join(base_dir, "Results", "outlook_web_pool.jsonl"),
+        "state_file": os.path.join(base_dir, "Results", "outlook_web_pool_state.json"),
+        "reader_script": os.path.join(base_dir, "webmail_reader.py"),
+        "python": os.path.join(base_dir, ".venv", "Scripts", "python.exe"),
+    }
+
+
+def _load_outlook_pool(pool_file):
+    records = []
+    with open(pool_file, "r", encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                item = json.loads(line)
+            except Exception:
+                continue
+            if not isinstance(item, dict):
+                continue
+            record_id = str(item.get("id", "")).strip()
+            email = str(item.get("email", "")).strip()
+            session_file = str(item.get("session_file", "")).strip()
+            if record_id and email and session_file:
+                records.append(item)
+    return records
+
+
+def _load_outlook_state(state_file):
+    if not os.path.exists(state_file):
+        return {"records": {}}
+    try:
+        with open(state_file, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except Exception:
+        return {"records": {}}
+    if not isinstance(value, dict) or not isinstance(value.get("records"), dict):
+        return {"records": {}}
+    return value
+
+
+def _save_outlook_state(state_file, state):
+    os.makedirs(os.path.dirname(state_file), exist_ok=True)
+    temp_file = f"{state_file}.{os.getpid()}.tmp"
+    with open(temp_file, "w", encoding="utf-8") as handle:
+        json.dump(state, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temp_file, state_file)
+    try:
+        os.chmod(state_file, 0o600)
+    except Exception:
+        pass
+
+
+def outlook_web_update_status(record_id, status, error=""):
+    paths = _outlook_web_paths()
+    lock = FileLock(paths["state_file"] + ".lock")
+    with lock:
+        state = _load_outlook_state(paths["state_file"])
+        previous = state["records"].get(record_id, {})
+        state["records"][record_id] = {
+            **previous,
+            "status": status,
+            "updated_at": time.time(),
+            "error": str(error or "")[:300],
+        }
+        _save_outlook_state(paths["state_file"], state)
+
+
+def outlook_web_get_email_and_token():
+    paths = _outlook_web_paths()
+    records = _load_outlook_pool(paths["pool_file"])
+    if not records:
+        raise RuntimeError("Outlook 网页邮箱池没有可用记录")
+
+    stale_after = 15 * 60
+    lock = FileLock(paths["state_file"] + ".lock")
+    with lock:
+        state = _load_outlook_state(paths["state_file"])
+        now = time.time()
+        selected = None
+        for item in records:
+            record_id = str(item["id"])
+            item_state = state["records"].get(record_id, {})
+            status = str(item_state.get("status", "unused"))
+            updated_at = float(item_state.get("updated_at", 0) or 0)
+            available = status in {"unused", "retryable"}
+            if status == "in_progress" and now - updated_at >= stale_after:
+                available = True
+            if available:
+                selected = item
+                attempts = int(item_state.get("attempts", 0) or 0) + 1
+                state["records"][record_id] = {
+                    **item_state,
+                    "status": "in_progress",
+                    "attempts": attempts,
+                    "updated_at": now,
+                    "error": "",
+                }
+                _save_outlook_state(paths["state_file"], state)
+                break
+    if selected is None:
+        raise RuntimeError("Outlook 网页邮箱池已用尽，或邮箱正在处理中")
+    return str(selected["email"]), f"outlook-web:{selected['id']}"
+
+
+def outlook_web_get_oai_code(
+    dev_token,
+    email,
+    timeout=180,
+    poll_interval=3,
+    log_callback=None,
+    cancel_callback=None,
+    resend_callback=None,
+):
+    del email, resend_callback
+    prefix = "outlook-web:"
+    if not str(dev_token).startswith(prefix):
+        raise RuntimeError("Outlook 网页邮箱 credential 格式错误")
+    record_id = str(dev_token)[len(prefix):].strip()
+    paths = _outlook_web_paths()
+    command = [
+        paths["python"],
+        paths["reader_script"],
+        "--pool-file", paths["pool_file"],
+        "--record-id", record_id,
+        "--timeout", str(int(timeout)),
+        "--poll-interval", str(float(poll_interval)),
+    ]
+    if bool(config.get("outlook_web_headless", False)):
+        command.append("--headless")
+    if log_callback:
+        log_callback("[*] 正在通过 Outlook 网页收件箱等待验证码")
+
+    process = subprocess.Popen(
+        command,
+        cwd=paths["base_dir"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    deadline = time.time() + timeout + 45
+    try:
+        while process.poll() is None:
+            raise_if_cancelled(cancel_callback)
+            if time.time() >= deadline:
+                process.terminate()
+                raise TimeoutError("Outlook 网页收信进程超时")
+            time.sleep(0.2)
+        stdout, stderr = process.communicate(timeout=5)
+    except Exception:
+        if process.poll() is None:
+            process.terminate()
+        try:
+            process.communicate(timeout=5)
+        except Exception:
+            process.kill()
+        outlook_web_update_status(record_id, "retryable", "reader interrupted")
+        raise
+
+    result = None
+    for line in str(stdout or "").splitlines():
+        if line.startswith("OUTLOOK_WEB_RESULT="):
+            try:
+                result = json.loads(line.split("=", 1)[1])
+            except Exception:
+                result = None
+    if isinstance(result, dict) and result.get("status") == "ok" and result.get("code"):
+        code = str(result["code"])
+        outlook_web_update_status(record_id, "consumed")
+        if log_callback:
+            log_callback(f"[*] Outlook 网页邮箱提取到验证码: {code}")
+        return code
+
+    error = "Outlook 网页收信失败"
+    if isinstance(result, dict) and result.get("error"):
+        error = str(result["error"])
+    elif process.returncode:
+        error = f"Outlook 网页收信进程退出码 {process.returncode}"
+    if stderr and log_callback:
+        log_callback("[Debug] Outlook 网页收信进程返回错误")
+    outlook_web_update_status(record_id, "retryable", error)
+    raise RuntimeError(error)
+
 def get_domains(api_key=None):
     headers = {}
     key = api_key or get_duckmail_api_key()
@@ -558,6 +764,8 @@ def get_duckmail_api_key():
 
 def get_email_and_token(api_key=None):
     provider = get_email_provider()
+    if provider == "outlook_web":
+        return outlook_web_get_email_and_token()
     if provider == "yyds":
         return yyds_get_email_and_token(api_key=api_key, jwt=get_yyds_jwt())
     if provider == "cloudmail":
@@ -644,6 +852,16 @@ def get_oai_code(
     resend_callback=None,
 ):
     provider = get_email_provider()
+    if provider == "outlook_web":
+        return outlook_web_get_oai_code(
+            dev_token,
+            email,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            log_callback=log_callback,
+            cancel_callback=cancel_callback,
+            resend_callback=resend_callback,
+        )
     if provider == "yyds":
         return yyds_get_oai_code(
             dev_token,

--- a/start_outlook_register.ps1
+++ b/start_outlook_register.ps1
@@ -1,0 +1,38 @@
+$ErrorActionPreference = "Stop"
+
+$outlookRoot = "G:\OutlookRegister"
+$python = Join-Path $outlookRoot ".venv\Scripts\python.exe"
+$registerScript = Join-Path $outlookRoot "main.py"
+$pidFile = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) ".outlook-register.pid"
+
+try {
+    if (-not (Test-Path -LiteralPath $python)) {
+        throw "OutlookRegister Python environment was not found: $python"
+    }
+    if (-not (Test-Path -LiteralPath $registerScript)) {
+        throw "OutlookRegister script was not found: $registerScript"
+    }
+
+    $running = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Name -in @("python.exe", "pythonw.exe") -and
+            $_.CommandLine -like "*OutlookRegister*main.py*"
+        } |
+        Select-Object -First 1
+    if ($running) {
+        Write-Host "Microsoft mailbox register is already running."
+        exit 0
+    }
+
+    $process = Start-Process `
+        -FilePath $python `
+        -ArgumentList @("-B", $registerScript) `
+        -WorkingDirectory $outlookRoot `
+        -PassThru
+    Set-Content -LiteralPath $pidFile -Value $process.Id -Encoding ASCII
+    Write-Host "Microsoft mailbox register started."
+    exit 0
+} catch {
+    Write-Host "[ERROR] $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}

--- a/stop_outlook_register.ps1
+++ b/stop_outlook_register.ps1
@@ -1,0 +1,38 @@
+$ErrorActionPreference = "Stop"
+
+$projectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$pidFile = Join-Path $projectRoot ".outlook-register.pid"
+$stopped = $false
+
+try {
+    $processes = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Name -in @("python.exe", "pythonw.exe") -and
+            $_.CommandLine -like "*OutlookRegister*main.py*"
+        }
+
+    foreach ($process in $processes) {
+        Stop-Process -Id $process.ProcessId -Force -ErrorAction SilentlyContinue
+        $stopped = $true
+    }
+
+    if (Test-Path -LiteralPath $pidFile) {
+        $rawPid = (Get-Content -Raw -LiteralPath $pidFile).Trim()
+        $launcherPid = 0
+        if ([int]::TryParse($rawPid, [ref]$launcherPid) -and $launcherPid -gt 0) {
+            Stop-Process -Id $launcherPid -Force -ErrorAction SilentlyContinue
+            $stopped = $true
+        }
+        Remove-Item -LiteralPath $pidFile -Force -ErrorAction SilentlyContinue
+    }
+
+    if ($stopped) {
+        Write-Host "Microsoft mailbox register stopped."
+    } else {
+        Write-Host "Microsoft mailbox register is not running."
+    }
+    exit 0
+} catch {
+    Write-Host "[ERROR] $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}

--- a/tests/test_outlook_web_provider.py
+++ b/tests/test_outlook_web_provider.py
@@ -1,0 +1,120 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import app_config
+import mail_service
+
+
+class FakeReaderProcess:
+    def __init__(self, stdout, returncode=0):
+        self._stdout = stdout
+        self.returncode = returncode
+        self.stdout = None
+        self.stderr = None
+
+    def poll(self):
+        return self.returncode
+
+    def communicate(self, timeout=None):
+        return self._stdout, ""
+
+    def terminate(self):
+        self.returncode = 1
+
+    def kill(self):
+        self.returncode = 1
+
+
+class OutlookWebProviderTests(unittest.TestCase):
+    def setUp(self):
+        self.old_config = mail_service.config
+
+    def tearDown(self):
+        mail_service.config = self.old_config
+
+    def make_pool(self, directory):
+        base = Path(directory)
+        results = base / "Results"
+        results.mkdir(parents=True)
+        session_file = results / "session.json"
+        session_file.write_text("{}", encoding="utf-8")
+        record = {
+            "id": "record-1",
+            "email": "outlook-user@example.com",
+            "password": "secret-value",
+            "session_file": str(session_file),
+        }
+        (results / "outlook_web_pool.jsonl").write_text(
+            json.dumps(record) + "\n", encoding="utf-8"
+        )
+        return base
+
+    def test_provider_reserves_unused_record_without_exposing_password(self):
+        with tempfile.TemporaryDirectory() as directory:
+            base = self.make_pool(directory)
+            mail_service.config = {"outlook_register_dir": str(base)}
+            email, credential = mail_service.outlook_web_get_email_and_token()
+            self.assertEqual(email, "outlook-user@example.com")
+            self.assertEqual(credential, "outlook-web:record-1")
+            self.assertNotIn("secret-value", credential)
+
+            state = json.loads(
+                (base / "Results" / "outlook_web_pool_state.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(state["records"]["record-1"]["status"], "in_progress")
+
+    def test_consumed_record_is_not_selected_again(self):
+        with tempfile.TemporaryDirectory() as directory:
+            base = self.make_pool(directory)
+            mail_service.config = {"outlook_register_dir": str(base)}
+            mail_service.outlook_web_update_status("record-1", "consumed")
+            with self.assertRaisesRegex(RuntimeError, "邮箱池已用尽"):
+                mail_service.outlook_web_get_email_and_token()
+
+    def test_reader_result_updates_status_and_returns_code(self):
+        with tempfile.TemporaryDirectory() as directory:
+            base = self.make_pool(directory)
+            mail_service.config = {
+                "outlook_register_dir": str(base),
+                "outlook_web_headless": False,
+            }
+            output = 'OUTLOOK_WEB_RESULT={"status":"ok","code":"123456"}\n'
+            statuses = []
+            with patch.object(
+                mail_service.subprocess,
+                "Popen",
+                return_value=FakeReaderProcess(output),
+            ), patch.object(
+                mail_service,
+                "outlook_web_update_status",
+                side_effect=lambda record_id, status, error="": statuses.append((record_id, status)),
+            ), patch.object(
+                mail_service, "raise_if_cancelled", return_value=None, create=True
+            ):
+                code = mail_service.outlook_web_get_oai_code(
+                    "outlook-web:record-1",
+                    "outlook-user@example.com",
+                    timeout=1,
+                    poll_interval=0.1,
+                )
+            self.assertEqual(code, "123456")
+            self.assertIn(("record-1", "consumed"), statuses)
+
+    def test_runtime_validation_requires_exported_pool(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cfg = app_config.DEFAULT_CONFIG.copy()
+            cfg.update(
+                {
+                    "email_provider": "outlook_web",
+                    "outlook_register_dir": directory,
+                }
+            )
+            with self.assertRaisesRegex(app_config.ConfigError, "邮箱池"):
+                app_config.validate_run_requirements(cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds Microsoft Outlook mailbox register support alongside the existing registration flow:

- **mail_service.py**: new Outlook web provider module — pool/state file management (`_load_outlook_pool`, `_load_outlook_state`, `_save_outlook_state`), status updates (`outlook_web_update_status`), and email + OAI code fetching (`outlook_web_get_email_and_token`, `outlook_web_get_oai_code`).
- **build_pkce_probe.py**: interactive xAI Build Authorization Code + PKCE probe tool (useful for manual OAuth debugging).
- **start/stop_outlook_register.ps1**: PowerShell scripts to start/stop the OutlookRegister process (configure `$outlookRoot` to your install path).
- **tests/test_outlook_web_provider.py**: unit tests covering pool record reservation and password non-exposure.

## Notes

- No credentials, API keys, or local user paths are included (only a generic `G:\OutlookRegister` sample path in the PS1 launchers).
- Test placeholder password is `secret-value` — no real secrets shipped.