### PR TITLE
fix: serialize parallel observer updates

### DIFF
--- a/registration_parallel.py
+++ b/registration_parallel.py
@@ -61,6 +61,7 @@ def run_parallel_batch(count, callbacks, observer, runtime_namespace, accounts_o
         raise ValueError("parallel batch requires at least two active workers")
 
     stats_lock = threading.Lock()
+    observer_lock = threading.Lock()
     log_lock = threading.Lock()
     io_lock = threading.Lock()
     abort_event = threading.Event()
@@ -169,10 +170,11 @@ def run_parallel_batch(count, callbacks, observer, runtime_namespace, accounts_o
         )
 
         def worker_observer(batch, account, output):
-            with stats_lock:
-                snapshots[worker_id] = _summary_copy(batch)
-                total = _aggregate(snapshots)
-            observer(total, account, output)
+            with observer_lock:
+                with stats_lock:
+                    snapshots[worker_id] = _summary_copy(batch)
+                    total = _aggregate(snapshots)
+                observer(total, account, output)
 
         try:
             batch = run_batch(

--- a/tests/test_optional_multithread.py
+++ b/tests/test_optional_multithread.py
@@ -191,6 +191,7 @@ class OptionalMultithreadTests(unittest.TestCase):
         self.assertTrue(all(module.browser is None and module.page is None for module in browser_modules))
         self.assertTrue(observed)
         self.assertLessEqual(max(observed), 5)
+        self.assertEqual(observed, sorted(observed))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix the remaining small race in optional multithread registration statistics.

### Change
- add a dedicated `observer_lock` in `registration_parallel.py`;
- serialize the complete `snapshot -> aggregate -> observer` sequence so an older aggregate cannot be delivered after a newer one;
- keep `stats_lock`, worker scheduling, browser/mail isolation, file output locking, CPA, grok2api, GUI and serial execution unchanged;
- extend the existing parallel coordinator regression test to require monotonic observed `processed_count` values.

This is intentionally a minimal two-file change.