### PR TITLE
fix: harden proxy pool cancellation and redaction

### DIFF
--- a/.proxy-pool-postmerge-trigger
+++ b/.proxy-pool-postmerge-trigger
@@ -1,0 +1,1 @@
+post-merge hardening

--- a/.proxy-pool-postmerge-trigger
+++ b/.proxy-pool-postmerge-trigger
@@ -1,1 +1,0 @@
-post-merge hardening

--- a/browser_runtime.py
+++ b/browser_runtime.py
@@ -13,6 +13,7 @@ from proxy_pool import (
     ProxyTransportError,
     current_proxy_lease,
     managed_proxy_active,
+    safe_proxy_error_text,
 )
 
 _config = {}
@@ -187,7 +188,7 @@ def http_get(url, **kwargs):
     except Exception as exc:
         if is_proxy_connection_error(exc):
             if managed_proxy_active():
-                raise ProxyTransportError(str(exc)) from exc
+                raise ProxyTransportError(safe_proxy_error_text(exc)) from exc
             direct = dict(request_kwargs)
             direct.pop("proxies", None)
             return requests.get(url, **direct)
@@ -201,7 +202,7 @@ def http_post(url, **kwargs):
     except Exception as exc:
         if is_proxy_connection_error(exc):
             if managed_proxy_active():
-                raise ProxyTransportError(str(exc)) from exc
+                raise ProxyTransportError(safe_proxy_error_text(exc)) from exc
             direct = dict(request_kwargs)
             direct.pop("proxies", None)
             return requests.post(url, **direct)

--- a/proxy_pool.py
+++ b/proxy_pool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import os
+import re
 import secrets
 import threading
 import time
@@ -28,6 +29,10 @@ class ProxyPoolError(RuntimeError):
 
 
 class ProxyAcquireTimeout(ProxyPoolError):
+    pass
+
+
+class ProxyAcquireCancelled(ProxyPoolError):
     pass
 
 
@@ -125,6 +130,14 @@ def proxy_log_label(value):
         )
     except Exception:
         return "(proxy)"
+
+
+_CREDENTIAL_URL_RE = re.compile(r"(?i)\b(https?|socks4a?|socks5h?)://([^/\s@]+)@")
+
+
+def safe_proxy_error_text(value):
+    text = str(value or "")
+    return _CREDENTIAL_URL_RE.sub(lambda match: match.group(1) + "://***@", text)
 
 
 def _node_id(proxy_url):
@@ -258,16 +271,37 @@ class ProxyPoolManager:
         if parsed.scheme not in ("http", "https") or not parsed.netloc:
             raise ProxyPoolError("代理订阅必须是有效的 http/https URL")
         via = str(self.config.get("proxy_pool_subscription_proxy") or "").strip()
+        if via:
+            via = normalize_proxy_url(via)
         proxies = {"http": via, "https": via} if via else {}
-        response = requests.get(
-            url,
-            proxies=proxies,
-            timeout=min(max(self.probe_timeout, 5), 60),
-            allow_redirects=True,
-            headers={"Accept": "text/plain, text/*;q=0.9, */*;q=0.1"},
-        )
-        if not 200 <= int(response.status_code) < 300:
-            raise ProxyPoolError("代理订阅返回 HTTP %s" % response.status_code)
+        current_url = url
+        response = None
+        for redirect_count in range(4):
+            try:
+                response = requests.get(
+                    current_url,
+                    proxies=proxies,
+                    timeout=min(max(self.probe_timeout, 5), 60),
+                    allow_redirects=False,
+                    headers={"Accept": "text/plain, text/*;q=0.9, */*;q=0.1"},
+                )
+            except Exception as exc:
+                raise ProxyPoolError("代理订阅请求失败: %s" % safe_proxy_error_text(exc)) from exc
+            status_code = int(response.status_code)
+            if status_code not in (301, 302, 303, 307, 308):
+                break
+            if redirect_count >= 3:
+                raise ProxyPoolError("代理订阅重定向次数超过 3 次")
+            location = str((getattr(response, "headers", {}) or {}).get("location") or "").strip()
+            if not location:
+                raise ProxyPoolError("代理订阅重定向缺少 Location")
+            current_url = urllib.parse.urljoin(current_url, location)
+            redirected = urllib.parse.urlsplit(current_url)
+            if redirected.scheme not in ("http", "https") or not redirected.netloc:
+                raise ProxyPoolError("代理订阅重定向地址无效")
+        if response is None or not 200 <= int(response.status_code) < 300:
+            status_code = int(getattr(response, "status_code", 0) or 0)
+            raise ProxyPoolError("代理订阅返回 HTTP %s" % status_code)
         body = str(response.text or "")
         if len(body.encode("utf-8", "ignore")) > _MAX_SOURCE_BYTES:
             raise ProxyPoolError("代理订阅内容超过 2 MiB 限制")
@@ -290,7 +324,7 @@ class ProxyPoolManager:
             try:
                 values.extend(loader())
             except Exception as exc:
-                errors.append(str(exc))
+                errors.append(safe_proxy_error_text(exc))
         unique = []
         seen = set()
         for source, value in values:
@@ -348,7 +382,7 @@ class ProxyPoolManager:
             try:
                 self.reload_sources(force=True)
             except Exception as exc:
-                self.log("[!] 代理池刷新失败，继续使用当前节点: %s" % exc)
+                self.log("[!] 代理池刷新失败，继续使用当前节点: %s" % safe_proxy_error_text(exc))
 
     def _schedule_periodic_probe_if_due(self):
         if not self.managed or self.probe_interval <= 0:
@@ -399,7 +433,7 @@ class ProxyPoolManager:
                 return ProxyLease("fallback-single", _expand_account_placeholder(proxy_url, session_key), worker_key, slot_index, attempt_index, affinity, session_key)
         return None
 
-    def acquire(self, affinity, worker_key, slot_index, attempt_index, session_key, timeout=None):
+    def acquire(self, affinity, worker_key, slot_index, attempt_index, session_key, timeout=None, cancel_callback=None):
         if not self.managed:
             return None
         self.refresh_if_due()
@@ -407,6 +441,8 @@ class ProxyPoolManager:
         deadline = time.time() + float(timeout if timeout is not None else self.acquire_timeout)
         with self._condition:
             while True:
+                if cancel_callback and cancel_callback():
+                    raise ProxyAcquireCancelled("代理租约等待已取消")
                 now = time.time()
                 eligible = self._eligible_locked(now)
                 if eligible:
@@ -465,7 +501,7 @@ class ProxyPoolManager:
         with self._lock:
             node = self._nodes.get(lease.node_id)
             if node is not None:
-                node.last_error = "soft: %s" % str(error or "")[:160]
+                node.last_error = "soft: %s" % safe_proxy_error_text(error)[:160]
 
     def report_transport_failure(self, lease, error):
         if lease is None or lease.node_id in ("direct", "fallback-single"):
@@ -533,7 +569,7 @@ class ProxyPoolManager:
             exit_ip = self._parse_probe_ip(response)
             status = "healthy"
         except Exception as exc:
-            error = str(exc)
+            error = safe_proxy_error_text(exc)
         latency = int((time.monotonic() - started) * 1000)
         with self._condition:
             node = self._nodes.get(node_id)
@@ -664,7 +700,7 @@ def managed_proxy_active():
     return current_proxy_lease() is not None
 
 
-def begin_registration_slot(slot_index, attempt_index=1, worker_key=None, log=None):
+def begin_registration_slot(slot_index, attempt_index=1, worker_key=None, log=None, cancel_callback=None):
     if current_proxy_lease() is not None:
         raise ProxyPoolError("当前线程已有未释放的代理租约")
     manager = get_manager(log=log)
@@ -682,6 +718,7 @@ def begin_registration_slot(slot_index, attempt_index=1, worker_key=None, log=No
         slot_index=slot,
         attempt_index=attempt,
         session_key=session_key,
+        cancel_callback=cancel_callback,
     )
     _TLS.lease = lease
     if log is not None:
@@ -715,4 +752,4 @@ def manager_snapshot(config=None):
     try:
         return get_manager(config=config).snapshot()
     except Exception as exc:
-        return {"mode": str((config or {}).get("proxy_mode") or "auto"), "managed": False, "nodes": [], "error": str(exc)}
+        return {"mode": str((config or {}).get("proxy_mode") or "auto"), "managed": False, "nodes": [], "error": safe_proxy_error_text(exc)}

--- a/registration_browser.py
+++ b/registration_browser.py
@@ -9,7 +9,7 @@ import time
 from DrissionPage import Chromium
 from DrissionPage.errors import PageDisconnectedError
 from curl_cffi import requests
-from proxy_pool import ProxyTransportError
+from proxy_pool import ProxyTransportError, safe_proxy_error_text
 
 browser = None
 page = None
@@ -246,7 +246,7 @@ def start_browser(log_callback=None, use_proxy=True):
             browser_started_with_proxy = False
             time.sleep(min(1.5 * attempt, 4))
     if _managed_proxy_mode() and is_proxy_connection_error(last_exc):
-        raise ProxyTransportError("Chromium 通过当前代理启动失败: %s" % last_exc) from last_exc
+        raise ProxyTransportError("Chromium 通过当前代理启动失败: %s" % safe_proxy_error_text(last_exc)) from last_exc
     raise Exception(f"浏览器启动失败，已重试4次: {last_exc}")
 
 def stop_browser():
@@ -384,7 +384,7 @@ def open_signup_page(log_callback=None, cancel_callback=None):
     except Exception as e:
         if browser_started_with_proxy and get_configured_proxy():
             if _managed_proxy_mode():
-                raise ProxyTransportError("当前代理访问注册页失败: %s" % e) from e
+                raise ProxyTransportError("当前代理访问注册页失败: %s" % safe_proxy_error_text(e)) from e
             if log_callback:
                 log_callback(f"[!] 浏览器代理访问注册页失败，自动回退直连: {e}")
             restart_browser(log_callback=log_callback, use_proxy=False)

--- a/registration_flow.py
+++ b/registration_flow.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 from app_config import config as app_config
 from proxy_pool import (
+    ProxyAcquireCancelled,
     ProxyPoolError,
     begin_registration_slot,
     current_proxy_lease,
@@ -362,6 +363,7 @@ def _run_batch_managed(settings, callbacks, observer, ops):
                     attempt_index=attempt_index,
                     worker_key=threading.current_thread().name,
                     log=callbacks.log,
+                    cancel_callback=callbacks.cancelled,
                 )
                 if first_browser_start or ops.browser_missing():
                     ops.start_browser()
@@ -383,6 +385,10 @@ def _run_batch_managed(settings, callbacks, observer, ops):
                 last_cleanup_success_count = _record_success(
                     result, settings, callbacks, ops, account, output, last_cleanup_success_count
                 )
+            except ProxyAcquireCancelled:
+                result.cancelled = True
+                callbacks.log("[!] 已在等待代理租约时停止")
+                continue_batch = False
             except ops.cancelled_exception:
                 result.cancelled = True
                 callbacks.log("[!] 注册被停止")

--- a/tests/test_proxy_pool.py
+++ b/tests/test_proxy_pool.py
@@ -4,7 +4,9 @@ import unittest
 from pathlib import Path
 
 from app_config import DEFAULT_CONFIG, validate_config_structure, validate_run_requirements
-from proxy_pool import ProxyPoolManager, parse_proxy_source
+from proxy_pool import (
+    ProxyAcquireCancelled, ProxyPoolManager, parse_proxy_source, safe_proxy_error_text,
+)
 
 
 class ProxyPoolTests(unittest.TestCase):
@@ -82,6 +84,24 @@ class ProxyPoolTests(unittest.TestCase):
         self.assertIn("user:***@", label)
         self.assertNotIn("secret", label)
         self.assertNotIn("password", label)
+
+    def test_acquire_honors_cancellation(self):
+        manager = ProxyPoolManager(self._config(proxy_mode="single", proxy="http://127.0.0.1:8001"))
+        with self.assertRaises(ProxyAcquireCancelled):
+            manager.acquire("a", "worker", 1, 1, "session", timeout=30, cancel_callback=lambda: True)
+
+    def test_release_is_idempotent(self):
+        manager = ProxyPoolManager(self._config(proxy_mode="single", proxy="http://127.0.0.1:8001"))
+        lease = manager.acquire("a", "worker", 1, 1, "session", timeout=1)
+        manager.release(lease)
+        manager.release(lease)
+        self.assertEqual(manager.snapshot()["nodes"][0]["inflight"], 0)
+
+    def test_proxy_error_text_masks_credentials(self):
+        value = safe_proxy_error_text("failed via socks5://secret:password@127.0.0.1:1080")
+        self.assertNotIn("secret", value)
+        self.assertNotIn("password", value)
+        self.assertIn("socks5://***@127.0.0.1:1080", value)
 
 
 if __name__ == "__main__":

--- a/web/proxy-pool.js
+++ b/web/proxy-pool.js
@@ -126,6 +126,7 @@
     } catch (_) {}
   }
   async function proxyAction(path) {
+    if (dirty.size && !await saveConfig()) return;
     const reload = document.getElementById('proxyReloadBtn');
     const test = document.getElementById('proxyTestBtn');
     if (reload) reload.disabled = true; if (test) test.disabled = true;


### PR DESCRIPTION
## Summary

- make managed proxy lease acquisition cooperative with Stop/cancel
- redact credentials from proxy-related error text before logs/status surfaces
- cap proxy subscription redirects at 3 and validate redirect URL schemes
- save dirty WebUI proxy settings before manual reload/test
- add focused regression coverage

This is a narrow post-merge hardening follow-up to the proxy-pool runtime; no registration behavior is changed outside managed proxy modes.

## Validation

- Python 3.9.25
- `python -m compileall -q .` passed
- `node --check web/proxy-pool.js` passed
- `git diff --check` passed
- `python -m unittest discover -s tests -v` passed: **110 tests**
- final PR diff contains only 6 product/test files; temporary trigger/workflow files are not part of the PR