### PR TITLE
fix: harden SSO risk gate after #73

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+      - fix/pr-73-sso-risk-hardening
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-web.txt
+          python -m pip install pytest
+      - name: Compile all Python modules
+        run: python -m compileall -q .
+      - name: Run unittest discovery
+        run: python -m unittest discover -s tests -v
+      - name: Run pytest suite
+        run: python -m pytest -q

--- a/sso_risk.py
+++ b/sso_risk.py
@@ -1,6 +1,8 @@
 """SSO 注册风控早停：读取 grok.com botFlagSource / policy，命中后隔离并跳过入库。"""
+import json
 import os
 import re
+import time
 
 from filelock import FileLock
 
@@ -19,6 +21,10 @@ class RegistrationRiskDenied(RuntimeError):
     """SSO 被 grok.com 风控标记，不应写入正常账号池或后处理。"""
 
 
+class RegistrationRiskPersistenceError(RuntimeError):
+    """风控已命中，但隔离文件和风险 pending 均无法持久化。"""
+
+
 def configure_risk_runtime(config_ref, http_get):
     global config, _http_get
     config = config_ref
@@ -32,55 +38,111 @@ def normalize_sso_token(raw_token):
     return token
 
 
+def _parse_detail_fields(details):
+    fields = {}
+    for item in str(details or "").split(","):
+        key, sep, value = item.partition("=")
+        if sep and key.strip():
+            fields[key.strip().lower()] = value.strip()
+    risk = None
+    try:
+        if fields.get("risk"):
+            risk = float(fields["risk"])
+    except (TypeError, ValueError):
+        risk = None
+    return {
+        "details": str(details or ""),
+        "policy": str(fields.get("policy") or "").strip().lower(),
+        "event": str(fields.get("event") or "").strip(),
+        "risk": risk,
+    }
+
+
 def parse_grok_account_state(page_html):
-    """从 grok.com 首页 RSC / HTML 解析账号注册风控状态。"""
+    """从 grok.com 首页 RSC / HTML 解析全部账号注册风控状态。"""
     raw = str(page_html or "")
     # Next.js 会把对象嵌入字符串，字段名通常表现为 \"botFlagSource\"。
     normalized = raw.replace('\\"', '"')
-    source_match = re.search(r'botFlagSource"\s*:\s*(null|-?\d+)', normalized)
-    details_match = re.search(
-        r'botFlagDetails"\s*:\s*(?:null|"([^"]*)")',
-        normalized,
+
+    source_matches = list(
+        re.finditer(r'botFlagSource"\s*:\s*(null|-?\d+)', normalized)
+    )
+    details_matches = list(
+        re.finditer(r'botFlagDetails"\s*:\s*(?:null|"([^"]*)")', normalized)
     )
 
-    source = None
-    if source_match and source_match.group(1) != "null":
+    sources = []
+    for match in source_matches:
+        raw_value = match.group(1)
+        if raw_value == "null":
+            sources.append(None)
+            continue
         try:
-            source = int(source_match.group(1))
+            sources.append(int(raw_value))
         except (TypeError, ValueError):
-            source = None
-    details = details_match.group(1) if details_match and details_match.group(1) else ""
+            sources.append(None)
 
-    detail_fields = {}
-    for item in details.split(","):
-        key, sep, value = item.partition("=")
-        if sep and key.strip():
-            detail_fields[key.strip().lower()] = value.strip()
-    risk = None
-    try:
-        if detail_fields.get("risk"):
-            risk = float(detail_fields["risk"])
-    except (TypeError, ValueError):
-        risk = None
-    policy = detail_fields.get("policy", "").lower()
-    event = detail_fields.get("event", "")
-    denied = policy == "deny" and event == "$registration"
+    detail_states = []
+    for match in details_matches:
+        detail_states.append(_parse_detail_fields(match.group(1) or ""))
+
+    # 兼容旧 scalar 字段：优先展示会触发 block 的值，否则展示第一个可解析值。
+    source = next((value for value in sources if value in (1, 2)), None)
+    if source is None:
+        source = next((value for value in sources if value is not None), None)
+
+    blocking_detail = next(
+        (item for item in detail_states if item.get("policy") == "deny"),
+        None,
+    )
+    selected_detail = blocking_detail or next(
+        (item for item in detail_states if item.get("details")),
+        None,
+    )
+    if selected_detail is None:
+        selected_detail = {"details": "", "policy": "", "event": "", "risk": None}
+
+    denied = any(
+        item.get("policy") == "deny" and item.get("event") == "$registration"
+        for item in detail_states
+    )
 
     return {
-        "found": bool(source_match or details_match),
+        "found": bool(source_matches or details_matches),
         "bot_flag_source": source,
-        "bot_flag_details": details,
-        "policy": policy,
-        "risk": risk,
-        "event": event,
+        "bot_flag_details": selected_detail.get("details", ""),
+        "policy": selected_detail.get("policy", ""),
+        "risk": selected_detail.get("risk"),
+        "event": selected_detail.get("event", ""),
         "denied": denied,
+        "bot_flag_sources": sources,
+        "bot_flag_detail_states": detail_states,
     }
+
+
+def _mark_proxy_transport_failure(result, exc):
+    """在 fail-open 前保留当前 lease 的可疑传输失败信号。"""
+    try:
+        from proxy_pool import current_proxy_lease, get_manager, is_proxy_transport_exception
+
+        if not is_proxy_transport_exception(exc):
+            return
+        result["transport_error"] = True
+        lease = current_proxy_lease()
+        if lease is not None:
+            try:
+                get_manager().report_suspected_transport_failure(lease, str(exc))
+            except Exception:
+                # health feedback 不能改变 risk gate 的 fail-open 产品语义。
+                pass
+    except Exception:
+        pass
 
 
 def inspect_sso_account_state(sso_cookie, proxy="", user_agent="", timeout=20, http_get=None):
     """读取 grok.com 当前账号状态；诊断失败时返回 unknown，不阻断入库。"""
     result = parse_grok_account_state("")
-    result.update({"status_code": 0, "url": "", "error": ""})
+    result.update({"status_code": 0, "url": "", "error": "", "transport_error": False})
     token = normalize_sso_token(sso_cookie)
     if not token:
         result["error"] = "sso 为空"
@@ -119,6 +181,7 @@ def inspect_sso_account_state(sso_cookie, proxy="", user_agent="", timeout=20, h
         return result
     except Exception as exc:
         result["error"] = str(exc)
+        _mark_proxy_transport_failure(result, exc)
         return result
 
 
@@ -126,23 +189,42 @@ def registration_risk_should_block(state):
     """是否隔离当前 SSO，阻止其进入正常账号池和后续 grok2api / CPA。
 
     命中条件：
-      - botFlagSource in (1, 2)
-      - policy=deny（含 $registration / $login）
-    读不到风控字段时不硬拦。
+      - 任一 botFlagSource in (1, 2)
+      - 任一 policy=deny（含 $registration / $login）
+    读不到风控字段或请求失败时不硬拦。
     """
     if not isinstance(state, dict):
         return False, ""
-    details = str(state.get("bot_flag_details") or "").strip()
-    bf = state.get("bot_flag_source")
-    policy = str(state.get("policy") or "").strip().lower()
-    event = str(state.get("event") or "").strip()
+
+    sources = state.get("bot_flag_sources")
+    if not isinstance(sources, (list, tuple)):
+        sources = [state.get("bot_flag_source")]
+
+    detail_states = state.get("bot_flag_detail_states")
+    if not isinstance(detail_states, (list, tuple)):
+        detail_states = [{
+            "details": state.get("bot_flag_details") or "",
+            "policy": state.get("policy") or "",
+            "event": state.get("event") or "",
+        }]
+
+    for item in detail_states:
+        if not isinstance(item, dict):
+            continue
+        policy = str(item.get("policy") or "").strip().lower()
+        if policy == "deny":
+            details = str(item.get("details") or "").strip()
+            event = str(item.get("event") or "").strip()
+            return True, details or ("policy=deny,event=%s" % (event or "unknown"))
+
+    for source in sources:
+        if source in (1, 2):
+            details = str(state.get("bot_flag_details") or "").strip()
+            return True, details or ("botFlagSource=%s" % source)
 
     if state.get("denied"):
+        details = str(state.get("bot_flag_details") or "").strip()
         return True, details or "policy=deny,event=$registration"
-    if bf in (1, 2):
-        return True, details or ("botFlagSource=%s" % bf)
-    if policy == "deny":
-        return True, details or ("policy=deny,event=%s" % (event or "unknown"))
     return False, ""
 
 
@@ -153,9 +235,16 @@ def resolve_rejected_file():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "sso_risk_rejected.txt")
 
 
-def append_sso_risk_rejected(email, sso, details, log_callback=None):
-    path = resolve_rejected_file()
-    safe_details = re.sub(r"[\r\n\t]+", " ", str(details or "")).strip()
+def resolve_rejected_pending_file():
+    return resolve_rejected_file() + ".pending.jsonl"
+
+
+def _safe_details(details):
+    return re.sub(r"[\r\n\t]+", " ", str(details or "")).strip()
+
+
+def _append_rejected_line(path, email, sso, details):
+    safe_details = _safe_details(details)
     line = "%s----%s----%s\n" % (email or "", sso, safe_details)
     parent = os.path.dirname(path) or "."
     os.makedirs(parent, exist_ok=True)
@@ -168,13 +257,161 @@ def append_sso_risk_rejected(email, sso, details, log_callback=None):
             os.chmod(path, 0o600)
         except Exception:
             pass
-    if log_callback:
-        log_callback("[风控] 已隔离到 %s" % path)
     return path
 
 
+def queue_sso_risk_rejected_pending(email, sso, details, primary_error="", state=None, log_callback=None):
+    """主隔离文件不可写时，把风险 SSO 写入独立 JSONL pending，绝不进入正常账号 pending。"""
+    path = resolve_rejected_pending_file()
+    parent = os.path.dirname(path) or "."
+    os.makedirs(parent, exist_ok=True)
+    payload = {
+        "email": str(email or ""),
+        "sso": normalize_sso_token(sso),
+        "details": _safe_details(details),
+        "primary_error": str(primary_error or ""),
+        "created_at": int(time.time()),
+    }
+    if isinstance(state, dict):
+        payload.update({
+            "bot_flag_source": state.get("bot_flag_source"),
+            "policy": state.get("policy"),
+            "event": state.get("event"),
+            "risk": state.get("risk"),
+        })
+    line = json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n"
+    with FileLock(path + ".lock", timeout=30):
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(line)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.chmod(path, 0o600)
+        except Exception:
+            pass
+    if log_callback:
+        log_callback("[风控] 主隔离文件写入失败，已保存到风险 pending: %s" % path)
+    return path
+
+
+def append_sso_risk_rejected(email, sso, details, log_callback=None, state=None):
+    """把风险 SSO 持久化；主文件失败时自动退避到独立 risk pending。"""
+    path = resolve_rejected_file()
+    try:
+        written = _append_rejected_line(path, email, sso, details)
+    except Exception as primary_exc:
+        try:
+            queue_sso_risk_rejected_pending(
+                email,
+                sso,
+                details,
+                primary_error=primary_exc,
+                state=state,
+                log_callback=log_callback,
+            )
+        except Exception as pending_exc:
+            raise RegistrationRiskPersistenceError(
+                "风控账号隔离与风险 pending 均写入失败: primary=%s; pending=%s"
+                % (primary_exc, pending_exc)
+            ) from pending_exc
+        return resolve_rejected_pending_file()
+
+    if log_callback:
+        log_callback("[风控] 已隔离到 %s" % written)
+    return written
+
+
+def _risk_identity(email, sso):
+    return "%s----%s----" % (str(email or ""), normalize_sso_token(sso))
+
+
+def retry_sso_risk_pending_file(pending_path=None, rejected_path=None, log_callback=None):
+    """幂等恢复风险 pending；成功条目进入 rejected，失败条目原子保留。"""
+    pending_path = os.path.abspath(
+        os.path.expanduser(str(pending_path or resolve_rejected_pending_file()))
+    )
+    rejected_path = os.path.abspath(
+        os.path.expanduser(str(rejected_path or resolve_rejected_file()))
+    )
+    if not os.path.exists(pending_path):
+        return {"processed": 0, "recovered": 0, "remaining": 0, "errors": []}
+
+    parent = os.path.dirname(pending_path) or "."
+    os.makedirs(parent, exist_ok=True)
+    errors = []
+    recovered = 0
+    processed = 0
+
+    with FileLock(pending_path + ".lock", timeout=30):
+        try:
+            with open(pending_path, "r", encoding="utf-8") as handle:
+                rows = [line.rstrip("\n") for line in handle if line.strip()]
+        except FileNotFoundError:
+            return {"processed": 0, "recovered": 0, "remaining": 0, "errors": []}
+
+        existing = set()
+        if os.path.exists(rejected_path):
+            try:
+                with open(rejected_path, "r", encoding="utf-8") as handle:
+                    for line in handle:
+                        parts = line.rstrip("\n").split("----", 2)
+                        if len(parts) >= 2:
+                            existing.add(_risk_identity(parts[0], parts[1]))
+            except Exception:
+                existing = set()
+
+        remaining_rows = []
+        for row in rows:
+            processed += 1
+            try:
+                payload = json.loads(row)
+                email = str(payload.get("email") or "")
+                sso = normalize_sso_token(payload.get("sso"))
+                details = str(payload.get("details") or "registration_risk")
+                if not sso:
+                    raise ValueError("risk pending row missing sso")
+                identity = _risk_identity(email, sso)
+                if identity not in existing:
+                    _append_rejected_line(rejected_path, email, sso, details)
+                    existing.add(identity)
+                recovered += 1
+            except Exception as exc:
+                remaining_rows.append(row)
+                errors.append(str(exc))
+
+        tmp_path = pending_path + ".tmp"
+        if remaining_rows:
+            with open(tmp_path, "w", encoding="utf-8") as handle:
+                for row in remaining_rows:
+                    handle.write(row + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, pending_path)
+        else:
+            try:
+                os.remove(pending_path)
+            except FileNotFoundError:
+                pass
+            try:
+                os.remove(tmp_path)
+            except FileNotFoundError:
+                pass
+
+    if log_callback:
+        log_callback(
+            "[风控] risk pending 恢复完成: processed=%s recovered=%s remaining=%s"
+            % (processed, recovered, len(remaining_rows))
+        )
+    return {
+        "processed": processed,
+        "recovered": recovered,
+        "remaining": len(remaining_rows),
+        "errors": errors,
+    }
+
+
 def ensure_sso_eligible(raw_token, email="", proxy="", user_agent="", log_callback=None, http_get=None):
-    """检查新账号风控状态；命中时写入隔离文件并拒绝正常入库。"""
+    """检查新账号风控状态；命中时持久化隔离并拒绝正常入库。"""
     if not bool((config or {}).get("sso_risk_gate_enabled", True)):
         return {"found": False, "skipped": True}
 
@@ -196,7 +433,13 @@ def ensure_sso_eligible(raw_token, email="", proxy="", user_agent="", log_callba
     block, details = registration_risk_should_block(state)
     if block:
         details = str(details or state.get("bot_flag_details") or "registration_risk")
-        append_sso_risk_rejected(email, sso, details, log_callback=log_callback)
+        append_sso_risk_rejected(
+            email,
+            sso,
+            details,
+            log_callback=log_callback,
+            state=state,
+        )
         raise RegistrationRiskDenied(
             "注册风控拒绝，已跳过入库: botFlagSource=%s %s"
             % (state.get("bot_flag_source"), details)

--- a/tests/test_sso_risk.py
+++ b/tests/test_sso_risk.py
@@ -1,9 +1,10 @@
-"""验证 SSO botFlag / policy 早停：解析、判定、隔离和入库拦截。"""
+"""验证 SSO botFlag / policy 早停：解析、判定、隔离、恢复和入库拦截。"""
+import json
 import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import sso_risk
 from registration_flow import (
@@ -29,17 +30,76 @@ def _html(source=2, details="risk=0.95,policy=deny,event=$registration"):
     )
 
 
+def _html_sequence(*states):
+    return "\n".join(_html(source, details) for source, details in states)
+
+
 class ParseAndPolicyTests(unittest.TestCase):
     def test_parse_escaped_next_payload(self):
         state = sso_risk.parse_grok_account_state(_html())
         self.assertTrue(state["found"])
         self.assertEqual(state["bot_flag_source"], 2)
+        self.assertEqual(state["bot_flag_sources"], [2])
         self.assertEqual(state["policy"], "deny")
         self.assertEqual(state["event"], "$registration")
         self.assertTrue(state["denied"])
         self.assertAlmostEqual(state["risk"], 0.95)
 
-    def test_block_policy(self):
+    def test_later_flagged_source_cannot_be_hidden_by_earlier_clean_state(self):
+        state = sso_risk.parse_grok_account_state(
+            _html_sequence(
+                (0, "risk=0.01,policy=allow,event=$registration"),
+                (2, "risk=0.95,policy=deny,event=$registration"),
+            )
+        )
+        self.assertEqual(state["bot_flag_sources"], [0, 2])
+        self.assertEqual(state["bot_flag_source"], 2)
+        blocked, detail = sso_risk.registration_risk_should_block(state)
+        self.assertTrue(blocked)
+        self.assertIn("policy=deny", detail)
+
+    def test_later_clean_state_cannot_clear_earlier_flagged_state(self):
+        state = sso_risk.parse_grok_account_state(
+            _html_sequence(
+                (1, "risk=0.90,policy=deny,event=$login"),
+                (0, "risk=0.01,policy=allow,event=$registration"),
+            )
+        )
+        self.assertEqual(state["bot_flag_sources"], [1, 0])
+        self.assertEqual(state["bot_flag_source"], 1)
+        self.assertTrue(sso_risk.registration_risk_should_block(state)[0])
+
+    def test_null_then_flagged_is_blocked(self):
+        state = sso_risk.parse_grok_account_state(
+            _html_sequence(
+                (None, ""),
+                (2, "risk=0.9,policy=allow,event=$registration"),
+            )
+        )
+        self.assertEqual(state["bot_flag_sources"], [None, 2])
+        self.assertTrue(sso_risk.registration_risk_should_block(state)[0])
+
+    def test_any_deny_detail_blocks_even_when_sources_are_clean(self):
+        state = sso_risk.parse_grok_account_state(
+            _html_sequence(
+                (0, "risk=0.01,policy=allow,event=$registration"),
+                (0, "risk=0.80,policy=deny,event=$login"),
+            )
+        )
+        self.assertEqual(state["bot_flag_source"], 0)
+        blocked, detail = sso_risk.registration_risk_should_block(state)
+        self.assertTrue(blocked)
+        self.assertIn("event=$login", detail)
+
+    def test_malformed_risk_float_does_not_crash(self):
+        state = sso_risk.parse_grok_account_state(
+            _html(0, "risk=not-a-number,policy=allow,event=$registration")
+        )
+        self.assertTrue(state["found"])
+        self.assertIsNone(state["risk"])
+        self.assertFalse(sso_risk.registration_risk_should_block(state)[0])
+
+    def test_block_policy_legacy_state_shape(self):
         blocked_cases = (
             ({"denied": True}, "policy=deny,event=$registration"),
             ({"bot_flag_source": 1}, "botFlagSource=1"),
@@ -82,6 +142,55 @@ class EnsureEligibleTests(unittest.TestCase):
         text = Path(sso_risk.resolve_rejected_file()).read_text(encoding="utf-8")
         self.assertIn("risk@example.test----flagged-token----", text)
         self.assertIn("policy=deny", text)
+        self.assertFalse(Path(sso_risk.resolve_rejected_pending_file()).exists())
+
+    def test_primary_quarantine_failure_falls_back_to_risk_pending(self):
+        response = SimpleNamespace(status_code=200, url="https://grok.com/", text=_html(2))
+        with patch("sso_risk._append_rejected_line", side_effect=OSError("disk full")):
+            with self.assertRaises(sso_risk.RegistrationRiskDenied):
+                sso_risk.ensure_sso_eligible(
+                    "flagged-token",
+                    email="risk@example.test",
+                    http_get=lambda *_args, **_kwargs: response,
+                )
+
+        pending = Path(sso_risk.resolve_rejected_pending_file())
+        self.assertTrue(pending.exists())
+        rows = [json.loads(line) for line in pending.read_text(encoding="utf-8").splitlines()]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["email"], "risk@example.test")
+        self.assertEqual(rows[0]["sso"], "flagged-token")
+        self.assertIn("disk full", rows[0]["primary_error"])
+
+    def test_risk_pending_recovery_is_idempotent(self):
+        sso_risk.queue_sso_risk_rejected_pending(
+            "risk@example.test",
+            "flagged-token",
+            "risk=0.95,policy=deny,event=$registration",
+            primary_error="disk full",
+        )
+        first = sso_risk.retry_sso_risk_pending_file()
+        second = sso_risk.retry_sso_risk_pending_file()
+
+        self.assertEqual(first["processed"], 1)
+        self.assertEqual(first["recovered"], 1)
+        self.assertEqual(first["remaining"], 0)
+        self.assertEqual(second["processed"], 0)
+        lines = Path(sso_risk.resolve_rejected_file()).read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(lines), 1)
+        self.assertTrue(lines[0].startswith("risk@example.test----flagged-token----"))
+
+    def test_primary_and_pending_failure_raise_dedicated_error(self):
+        with patch("sso_risk._append_rejected_line", side_effect=OSError("disk full")), patch(
+            "sso_risk.queue_sso_risk_rejected_pending",
+            side_effect=OSError("pending unavailable"),
+        ):
+            with self.assertRaises(sso_risk.RegistrationRiskPersistenceError):
+                sso_risk.append_sso_risk_rejected(
+                    "risk@example.test",
+                    "flagged-token",
+                    "policy=deny,event=$registration",
+                )
 
     def test_unknown_state_continues(self):
         response = SimpleNamespace(status_code=200, url="https://grok.com/", text="<html></html>")
@@ -90,6 +199,32 @@ class EnsureEligibleTests(unittest.TestCase):
             http_get=lambda *_args, **_kwargs: response,
         )
         self.assertFalse(state["found"])
+        self.assertFalse(Path(sso_risk.resolve_rejected_file()).exists())
+
+    def test_transport_failure_is_fail_open_but_reports_suspected_health(self):
+        class TransportError(RuntimeError):
+            pass
+
+        manager = Mock()
+        lease = object()
+
+        def failing_get(*_args, **_kwargs):
+            raise TransportError("proxy connection reset")
+
+        with patch("proxy_pool.is_proxy_transport_exception", return_value=True), patch(
+            "proxy_pool.current_proxy_lease", return_value=lease
+        ), patch("proxy_pool.get_manager", return_value=manager):
+            state = sso_risk.ensure_sso_eligible(
+                "transport-unknown-token",
+                http_get=failing_get,
+            )
+
+        self.assertFalse(state["found"])
+        self.assertTrue(state["transport_error"])
+        self.assertIn("proxy connection reset", state["error"])
+        manager.report_suspected_transport_failure.assert_called_once_with(
+            lease, "proxy connection reset"
+        )
         self.assertFalse(Path(sso_risk.resolve_rejected_file()).exists())
 
     def test_disabled_gate_skips_http(self):
@@ -146,6 +281,25 @@ class FlowGateTests(unittest.TestCase):
         self.assertFalse(any(item[0] == "tokens" for item in events))
         self.assertFalse(any(item[0] == "cpa" for item in events))
         self.assertTrue(any("注册风控拒绝" in line for line in logs))
+
+    def test_risk_persistence_failure_also_never_enters_normal_pool(self):
+        def screen(_sso, _email):
+            raise sso_risk.RegistrationRiskPersistenceError("quarantine unavailable")
+
+        ops, events = _ops(screen_sso=screen)
+        logs = []
+        batch = run_batch(
+            1,
+            RegistrationCallbacks(log=logs.append, cancelled=lambda: False),
+            lambda *a: None,
+            ops,
+        )
+        self.assertEqual(batch.success_count, 0)
+        self.assertEqual(batch.fail_count, 1)
+        self.assertFalse(any(item[0] == "persist" for item in events))
+        self.assertFalse(any(item[0] == "pending" for item in events))
+        self.assertFalse(any(item[0] == "tokens" for item in events))
+        self.assertFalse(any(item[0] == "cpa" for item in events))
 
     def test_persist_calls_screen_before_write(self):
         seen = []

--- a/tests/test_sso_risk_concurrency.py
+++ b/tests/test_sso_risk_concurrency.py
@@ -1,0 +1,85 @@
+"""SSO risk gate 的并发持久化与代理租约边界回归。"""
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+import sso_risk
+
+
+class SsoRiskConcurrencyTests(unittest.TestCase):
+    def setUp(self):
+        self._prev_config = sso_risk.config
+        self._prev_http = sso_risk._http_get
+        self.tmp = tempfile.TemporaryDirectory()
+        self.rejected = str(Path(self.tmp.name) / "sso_risk_rejected.txt")
+        sso_risk.configure_risk_runtime(
+            {"sso_risk_gate_enabled": True, "sso_risk_rejected_file": self.rejected},
+            None,
+        )
+
+    def tearDown(self):
+        sso_risk.config = self._prev_config
+        sso_risk._http_get = self._prev_http
+        self.tmp.cleanup()
+
+    def test_concurrent_risk_quarantine_appends_remain_complete(self):
+        def write_one(index):
+            return sso_risk.append_sso_risk_rejected(
+                "user%s@example.test" % index,
+                "sso-%s" % index,
+                "risk=0.95,policy=deny,event=$registration",
+            )
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(write_one, range(40)))
+
+        lines = Path(self.rejected).read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(lines), 40)
+        self.assertEqual(len(set(lines)), 40)
+        for index in range(40):
+            prefix = "user%s@example.test----sso-%s----" % (index, index)
+            self.assertTrue(any(line.startswith(prefix) for line in lines))
+
+    def test_risk_http_without_explicit_proxy_leaves_proxy_injection_to_runtime(self):
+        captured = {}
+
+        def getter(url, **kwargs):
+            captured["url"] = url
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                status_code=200,
+                url="https://grok.com/",
+                text='{"botFlagSource":0,"botFlagDetails":null}',
+            )
+
+        state = sso_risk.inspect_sso_account_state("sso-token", http_get=getter)
+        self.assertTrue(state["found"])
+        self.assertEqual(state["bot_flag_source"], 0)
+        self.assertNotIn("proxies", captured["kwargs"])
+
+    def test_explicit_proxy_is_still_forwarded_when_requested(self):
+        captured = {}
+
+        def getter(_url, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                status_code=200,
+                url="https://grok.com/",
+                text='{"botFlagSource":0,"botFlagDetails":null}',
+            )
+
+        sso_risk.inspect_sso_account_state(
+            "sso-token",
+            proxy="http://127.0.0.1:8899",
+            http_get=getter,
+        )
+        self.assertEqual(
+            captured["proxies"],
+            {"http": "http://127.0.0.1:8899", "https": "http://127.0.0.1:8899"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up hardening for merged PR #73.

This branch addresses the review blockers identified before merge:
- scan all `botFlagSource` / `botFlagDetails` occurrences so a later deny cannot be hidden by an earlier clean state;
- add a risk-specific `sso_risk_rejected.txt.pending.jsonl` fallback and idempotent recovery path when the primary quarantine file cannot be written;
- keep risk HTTP failures fail-open while reporting proxy transport failures as suspected lease-health failures;
- add regression tests for multi-state parsing, quarantine fallback/recovery, double-persistence failure, fail-open transport behavior, and flow-level non-persistence;
- add a CI workflow that runs compileall, unittest discovery, and pytest on Python 3.12.

This PR will remain draft until the full validation suite is green and the final diff has been re-reviewed.