### PR TITLE
Fix audited registration, proxy, WebUI, GUI, and CPA reliability issues

### DIFF
--- a/account_outputs.py
+++ b/account_outputs.py
@@ -26,9 +26,15 @@ def append_account_line(path, email, password, sso):
 
 def save_mail_credential(base_dir, email, credential):
     path = os.path.join(base_dir, "mail_credentials.txt")
+    record = f"{email}\t{credential}"
     with FileLock(path + ".lock", timeout=30):
+        if os.path.isfile(path):
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                for raw_line in handle:
+                    if raw_line.rstrip("\r\n") == record:
+                        return True
         with open(path, "a", encoding="utf-8") as handle:
-            handle.write(f"{email}\t{credential}\n")
+            handle.write(record + "\n")
             handle.flush()
             os.fsync(handle.fileno())
     return True

--- a/browser_runtime.py
+++ b/browser_runtime.py
@@ -20,6 +20,21 @@ _config = {}
 _extension_path = ""
 
 
+def _legacy_extension_path():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "turnstilePatch")
+
+
+def _resolve_extension_path(explicit=None):
+    if explicit is not None:
+        candidate = str(explicit or "").strip()
+        return candidate if candidate and os.path.isdir(candidate) else ""
+    configured = str(_extension_path or "").strip()
+    if configured and os.path.isdir(configured):
+        return configured
+    legacy = _legacy_extension_path()
+    return legacy if os.path.isdir(legacy) else ""
+
+
 def configure_runtime(config_ref, extension_path=""):
     global _config, _extension_path
     _config = config_ref
@@ -164,8 +179,8 @@ def create_browser_options(browser_proxy="", extension_path=None):
     options.auto_port()
     options.set_timeouts(base=1)
     apply_browser_proxy_option(options, browser_proxy)
-    effective_extension = _extension_path if extension_path is None else str(extension_path or "")
-    if effective_extension and os.path.exists(effective_extension):
+    effective_extension = _resolve_extension_path(extension_path)
+    if effective_extension:
         options.add_extension(effective_extension)
     return options
 

--- a/cpa_xai/browser_session.py
+++ b/cpa_xai/browser_session.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import os
 import threading
 import time
-from pathlib import Path
 from typing import Any, Callable, Optional
 
 LogFn = Callable[[str], None]
@@ -29,13 +28,10 @@ def create_standalone_page(proxy: Optional[str] = None, headless: bool = False, 
         raise BrowserConfirmError("DrissionPage not installed") from exc
 
     options = None
-    package_root = Path(__file__).resolve().parents[1]
     try:
         from browser_runtime import create_browser_options
 
-        options = create_browser_options(
-            extension_path=package_root / "turnstilePatch"
-        )
+        options = create_browser_options()
         logger("using shared browser_runtime.create_browser_options")
     except Exception as exc:  # noqa: BLE001
         logger("shared browser options unavailable: %s" % exc)
@@ -55,14 +51,6 @@ def create_standalone_page(proxy: Optional[str] = None, headless: bool = False, 
             "--window-size=1280,900",
         ):
             options.set_argument(flag)
-        extension = str(package_root / "turnstilePatch")
-        if os.path.isdir(extension):
-            try:
-                options.add_extension(extension)
-                logger("added extension %s" % extension)
-            except Exception as exc:  # noqa: BLE001
-                logger("extension add failed: %s" % exc)
-
     if headless:
         try:
             options.headless(True)

--- a/cpa_xai/schema.py
+++ b/cpa_xai/schema.py
@@ -43,7 +43,7 @@ def jwt_payload(token):
 
 
 def parse_identity(id_token=None, access_token=None):
-    """Return identity only; token lifetime is resolved separately."""
+    """Return the historical identity tuple; expiry consumers choose their token explicitly."""
     for candidate in (id_token, access_token):
         if not candidate:
             continue
@@ -54,8 +54,10 @@ def parse_identity(id_token=None, access_token=None):
         return (
             str(payload.get("email") or "").strip(),
             str(payload.get("sub") or payload.get("principal_id") or "").strip(),
+            int(payload.get("exp") or 0),
+            int(payload.get("iat") or 0),
         )
-    return "", ""
+    return "", "", 0, 0
 
 
 def _jwt_times(token):
@@ -84,7 +86,10 @@ def build_cpa_xai_auth(
         raise ValueError("access_token is required")
     if not refresh:
         raise ValueError("refresh_token is required")
-    parsed_email, subject = parse_identity(id_token=id_token, access_token=access)
+    parsed_email, subject, _identity_exp, _identity_iat = parse_identity(
+        id_token=id_token,
+        access_token=access,
+    )
     final_email = str(email or parsed_email or "").strip()
     access_exp, access_iat = _jwt_times(access)
     now_ts = int(time.time())

--- a/cpa_xai/schema.py
+++ b/cpa_xai/schema.py
@@ -43,6 +43,7 @@ def jwt_payload(token):
 
 
 def parse_identity(id_token=None, access_token=None):
+    """Return identity only; token lifetime is resolved separately."""
     for candidate in (id_token, access_token):
         if not candidate:
             continue
@@ -53,10 +54,18 @@ def parse_identity(id_token=None, access_token=None):
         return (
             str(payload.get("email") or "").strip(),
             str(payload.get("sub") or payload.get("principal_id") or "").strip(),
-            int(payload.get("exp") or 0),
-            int(payload.get("iat") or 0),
         )
-    return "", "", 0, 0
+    return "", ""
+
+
+def _jwt_times(token):
+    if not token:
+        return 0, 0
+    try:
+        payload = jwt_payload(token)
+    except Exception:
+        return 0, 0
+    return int(payload.get("exp") or 0), int(payload.get("iat") or 0)
 
 
 def build_cpa_xai_auth(
@@ -75,28 +84,39 @@ def build_cpa_xai_auth(
         raise ValueError("access_token is required")
     if not refresh:
         raise ValueError("refresh_token is required")
-    parsed_email, subject, exp, iat = parse_identity(id_token=id_token, access_token=access)
+    parsed_email, subject = parse_identity(id_token=id_token, access_token=access)
     final_email = str(email or parsed_email or "").strip()
+    access_exp, access_iat = _jwt_times(access)
+    now_ts = int(time.time())
+    provided_expires_in = expires_in is not None
     if expires_in is None:
-        if exp and iat and exp >= iat:
-            expires_in = exp - iat
-        elif exp:
-            expires_in = max(exp - int(time.time()), 0)
+        if access_exp and access_iat and access_exp >= access_iat:
+            expires_in = access_exp - access_iat
+        elif access_exp:
+            expires_in = max(access_exp - now_ts, 0)
         else:
             expires_in = 21600
-    expired = ""
-    if exp:
-        expired = datetime.fromtimestamp(exp, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    elif expires_in:
-        expired = datetime.fromtimestamp(time.time() + int(expires_in or 0), tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    expires_in = max(0, int(expires_in or 0))
+    if provided_expires_in:
+        expired_ts = now_ts + expires_in
+    elif access_exp:
+        expired_ts = access_exp
+    else:
+        expired_ts = now_ts + expires_in
+    expired = (
+        datetime.fromtimestamp(expired_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if expired_ts
+        else ""
+    )
+    refreshed_at = datetime.fromtimestamp(now_ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     payload = {
         "type": "xai",
         "access_token": access,
         "refresh_token": refresh,
         "token_type": "Bearer",
-        "expires_in": int(expires_in or 0),
+        "expires_in": expires_in,
         "expired": expired,
-        "last_refresh": datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "last_refresh": refreshed_at,
         "email": final_email,
         "sub": subject,
         "base_url": str(base_url or DEFAULT_BASE_URL).rstrip("/") or DEFAULT_BASE_URL,

--- a/grok_register_ttk.py
+++ b/grok_register_ttk.py
@@ -708,6 +708,7 @@ class GrokRegisterGUI:
         self.root.minsize(960, 700)
         self.operation_lock = threading.Lock()
         self.is_running = False
+        self.registration_starting = False
         self.proxy_test_running = False
         self.batch_count = 0
         self.success_count = 0
@@ -1123,8 +1124,8 @@ class GrokRegisterGUI:
 
     def test_proxy_pool(self):
         with self.operation_lock:
-            if self.is_running:
-                reason = "[!] 注册任务运行期间不能手动测试代理池"
+            if self.is_running or self.registration_starting:
+                reason = "[!] 注册任务启动或运行期间不能手动测试代理池"
             elif self.proxy_test_running:
                 reason = "[!] 代理池测试已在运行"
             else:
@@ -1179,12 +1180,13 @@ class GrokRegisterGUI:
 
     def start_registration(self):
         with self.operation_lock:
-            if self.is_running:
-                reason = "[!] 当前已有任务在运行"
+            if self.is_running or self.registration_starting:
+                reason = "[!] 当前已有任务正在启动或运行"
             elif self.proxy_test_running:
                 reason = "[!] 代理池测试进行中，暂不能启动注册"
             else:
                 reason = ""
+                self.registration_starting = True
         if reason:
             self.log(reason)
             return
@@ -1237,8 +1239,13 @@ class GrokRegisterGUI:
             config.update(validated)
             save_config()
         except (ValueError, ConfigError) as exc:
+            with self.operation_lock:
+                self.registration_starting = False
             self.log(f"[!] 配置无效或保存失败: {exc}")
             return
+        with self.operation_lock:
+            self.registration_starting = False
+            self.is_running = True
         self.stop_requested = False
         self._reset_batch_counters()
         self.results = []
@@ -1247,7 +1254,7 @@ class GrokRegisterGUI:
             os.path.dirname(__file__), f"accounts_{now}.txt"
         )
         self.update_stats()
-        self._set_running_ui(True)
+        self.ui_queue.put(("running", True))
         self.log(f"[*] 配置已保存，开始执行。目标数量: {count}")
         if config.get("multi_thread_enabled") and int(config.get("multi_thread_workers", 4)) > 1 and count > 1:
             actual_workers = min(count, int(config.get("multi_thread_workers", 4)))

--- a/grok_register_ttk.py
+++ b/grok_register_ttk.py
@@ -144,10 +144,6 @@ def warn_runtime_compatibility():
 ensure_stable_python_runtime()
 warn_runtime_compatibility()
 
-EXTENSION_PATH = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "turnstilePatch")
-)
-
 
 
 
@@ -253,7 +249,7 @@ def _make_compat_proxy(module, name, binder=None):
 
 
 def _bind_browser_runtime():
-    _browser_runtime.configure_runtime(config, EXTENSION_PATH)
+    _browser_runtime.configure_runtime(config)
 
 
 def _bind_account_outputs():
@@ -710,10 +706,13 @@ class GrokRegisterGUI:
         self.root.title("Grok 注册机")
         self.root.geometry("1120x900")
         self.root.minsize(960, 700)
+        self.operation_lock = threading.Lock()
         self.is_running = False
+        self.proxy_test_running = False
         self.batch_count = 0
         self.success_count = 0
         self.fail_count = 0
+        self.uncertain_count = 0
         self.registered_unsaved_count = 0
         self.postprocess_warning_count = 0
         self.results = []
@@ -976,6 +975,16 @@ class GrokRegisterGUI:
         self.proxy_protocol_start_timeout_spinbox = tk.Spinbox(config_frame, from_=3, to=60, width=8, textvariable=self.proxy_protocol_start_timeout_var, bg=UI_ENTRY_BG, fg=UI_FG, insertbackground=UI_FG, buttonbackground=UI_BUTTON_BG, relief=tk.SOLID)
         add_field(self.proxy_protocol_start_timeout_spinbox, 20, 1, sticky=tk.W)
 
+        add_label(21, 0, "YYDS API Key:")
+        self.yyds_api_key_var = tk.StringVar(value=str(config.get("yyds_api_key", "")))
+        self.yyds_api_key_entry = tk_entry(config_frame, textvariable=self.yyds_api_key_var, width=34, show="*")
+        add_field(self.yyds_api_key_entry, 21, 1)
+
+        add_label(21, 2, "YYDS JWT:")
+        self.yyds_jwt_var = tk.StringVar(value=str(config.get("yyds_jwt", "")))
+        self.yyds_jwt_entry = tk_entry(config_frame, textvariable=self.yyds_jwt_var, width=34, show="*")
+        add_field(self.yyds_jwt_entry, 21, 3)
+
         btn_frame = tk.Frame(main_frame, bg=UI_BG)
         btn_frame.grid(row=1, column=0, sticky=tk.EW, pady=(0, 6))
         self.start_btn = tk_button(btn_frame, text="开始注册", command=self.start_registration)
@@ -991,7 +1000,7 @@ class GrokRegisterGUI:
         tk_label(status_frame, text="状态: ").pack(side=tk.LEFT)
         self.status_label = tk.Label(status_frame, textvariable=self.status_var, bg=UI_BG, fg="green")
         self.status_label.pack(side=tk.LEFT)
-        self.stats_var = tk.StringVar(value="成功: 0 | 失败: 0 | 待恢复: 0 | 后处理警告: 0")
+        self.stats_var = tk.StringVar(value="成功: 0 | 失败: 0 | 结果不确定: 0 | 待恢复: 0 | 后处理警告: 0")
         tk.Label(status_frame, textvariable=self.stats_var, bg=UI_BG, fg=UI_FG).pack(side=tk.RIGHT)
         log_frame = tk.LabelFrame(
             main_frame,
@@ -1036,13 +1045,28 @@ class GrokRegisterGUI:
                 elif kind == "clear_log":
                     self.log_text.delete(1.0, tk.END)
                 elif kind == "stats":
-                    self.stats_var.set(f"成功: {event[1]} | 失败: {event[2]} | 待恢复: {event[3]} | 后处理警告: {event[4]}")
+                    self.stats_var.set(
+                        f"成功: {event[1]} | 失败: {event[2]} | 结果不确定: {event[3]} | "
+                        f"待恢复: {event[4]} | 后处理警告: {event[5]}"
+                    )
                 elif kind == "running":
                     running = bool(event[1])
-                    self.start_btn.config(state=tk.DISABLED if running else tk.NORMAL)
+                    with self.operation_lock:
+                        testing = bool(self.proxy_test_running)
+                    self.start_btn.config(state=tk.DISABLED if (running or testing) else tk.NORMAL)
+                    self.proxy_test_btn.config(state=tk.DISABLED if (running or testing) else tk.NORMAL)
                     self.stop_btn.config(state=tk.NORMAL if running else tk.DISABLED)
-                    self.status_var.set("运行中..." if running else "就绪")
-                    self.status_label.config(foreground="blue" if running else "green")
+                    self.status_var.set("运行中..." if running else ("测试代理池..." if testing else "就绪"))
+                    self.status_label.config(foreground="blue" if (running or testing) else "green")
+                elif kind == "proxy_test":
+                    testing = bool(event[1])
+                    with self.operation_lock:
+                        running = bool(self.is_running)
+                    self.start_btn.config(state=tk.DISABLED if (running or testing) else tk.NORMAL)
+                    self.proxy_test_btn.config(state=tk.DISABLED if (running or testing) else tk.NORMAL)
+                    if not running:
+                        self.status_var.set("测试代理池..." if testing else "就绪")
+                        self.status_label.config(foreground="blue" if testing else "green")
                 elif kind == "error":
                     messagebox.showerror(event[1], event[2])
         except queue.Empty:
@@ -1065,11 +1089,20 @@ class GrokRegisterGUI:
         self.ui_queue.put(("clear_log",))
 
     def update_stats(self):
-        self.ui_queue.put(("stats", self.success_count, self.fail_count, self.registered_unsaved_count, self.postprocess_warning_count))
+        self.ui_queue.put((
+            "stats",
+            self.success_count,
+            self.fail_count,
+            self.uncertain_count,
+            self.registered_unsaved_count,
+            self.postprocess_warning_count,
+        ))
 
     def _set_running_ui(self, running):
-        self.is_running = bool(running)
-        self.ui_queue.put(("running", self.is_running))
+        with self.operation_lock:
+            self.is_running = bool(running)
+            current = self.is_running
+        self.ui_queue.put(("running", current))
 
 
     def should_stop(self):
@@ -1078,6 +1111,7 @@ class GrokRegisterGUI:
     def _reset_batch_counters(self):
         self.success_count = 0
         self.fail_count = 0
+        self.uncertain_count = 0
         self.registered_unsaved_count = 0
         self.postprocess_warning_count = 0
 
@@ -1088,9 +1122,19 @@ class GrokRegisterGUI:
         self.multi_thread_workers_spinbox.config(state=state)
 
     def test_proxy_pool(self):
-        if self.is_running:
-            self.log("[!] 注册任务运行期间不能手动测试代理池")
+        with self.operation_lock:
+            if self.is_running:
+                reason = "[!] 注册任务运行期间不能手动测试代理池"
+            elif self.proxy_test_running:
+                reason = "[!] 代理池测试已在运行"
+            else:
+                reason = ""
+                self.proxy_test_running = True
+        if reason:
+            self.log(reason)
             return
+        self.ui_queue.put(("proxy_test", True))
+
         def worker():
             try:
                 candidate = dict(config)
@@ -1119,11 +1163,30 @@ class GrokRegisterGUI:
                 self.log("[*] 代理池测试完成: %s/%s 个节点健康" % (healthy, len(results)))
             except Exception as exc:
                 self.log("[!] 代理池测试失败: %s" % exc)
-        threading.Thread(target=worker, name="proxy-pool-gui-test", daemon=True).start()
+            finally:
+                with self.operation_lock:
+                    self.proxy_test_running = False
+                self.ui_queue.put(("proxy_test", False))
+
+        thread = threading.Thread(target=worker, name="proxy-pool-gui-test", daemon=True)
+        try:
+            thread.start()
+        except Exception:
+            with self.operation_lock:
+                self.proxy_test_running = False
+            self.ui_queue.put(("proxy_test", False))
+            raise
 
     def start_registration(self):
-        if self.is_running:
-            self.log("[!] 当前已有任务在运行")
+        with self.operation_lock:
+            if self.is_running:
+                reason = "[!] 当前已有任务在运行"
+            elif self.proxy_test_running:
+                reason = "[!] 代理池测试进行中，暂不能启动注册"
+            else:
+                reason = ""
+        if reason:
+            self.log(reason)
             return
 
         config["email_provider"] = self.email_provider_var.get().strip() or "duckmail"
@@ -1137,6 +1200,8 @@ class GrokRegisterGUI:
         config["proxy_protocol_backend"] = self.proxy_protocol_backend_var.get().strip() or "auto"
         config["proxy_singbox_path"] = self.proxy_singbox_path_var.get().strip()
         config["duckmail_api_key"] = self.api_key_var.get().strip()
+        config["yyds_api_key"] = self.yyds_api_key_var.get().strip()
+        config["yyds_jwt"] = self.yyds_jwt_var.get().strip()
         config["cloudflare_api_base"] = self.cloudflare_api_base_var.get().strip()
         config["cloudflare_api_key"] = self.cloudflare_api_key_var.get().strip()
         config["cloudflare_auth_mode"] = self.cloudflare_auth_mode_var.get().strip() or "none"
@@ -1204,6 +1269,7 @@ class GrokRegisterGUI:
         def observer(batch, account, output):
             self.success_count = batch.success_count
             self.fail_count = batch.fail_count
+            self.uncertain_count = batch.uncertain_count
             self.registered_unsaved_count = batch.registered_unsaved_count
             self.postprocess_warning_count = batch.postprocess_warning_count
             if account is not None:
@@ -1219,6 +1285,7 @@ class GrokRegisterGUI:
             )
             self.success_count = batch.success_count
             self.fail_count = batch.fail_count
+            self.uncertain_count = batch.uncertain_count
             self.registered_unsaved_count = batch.registered_unsaved_count
             self.postprocess_warning_count = batch.postprocess_warning_count
             self.update_stats()

--- a/grok_register_ttk.py
+++ b/grok_register_ttk.py
@@ -668,7 +668,11 @@ def run_registration_common(count, log_callback, cancel_callback, accounts_outpu
         restart_browser=lambda: restart_browser(log_callback=log_callback),
         browser_missing=lambda: _registration_browser.browser is None,
         open_signup_page=lambda: open_signup_page(log_callback=log_callback, cancel_callback=cancel_callback),
-        fill_email_and_submit=lambda: fill_email_and_submit(log_callback=log_callback, cancel_callback=cancel_callback),
+        fill_email_and_submit=lambda: fill_email_and_submit(
+            log_callback=log_callback,
+            cancel_callback=cancel_callback,
+            on_mail_created=lambda email, token: _save_mail_credential(email, token, log_callback),
+        ),
         save_mail_credential=lambda email, token: _save_mail_credential(email, token, log_callback),
         fill_code_and_submit=lambda email, token: fill_code_and_submit(email, token, log_callback=log_callback, cancel_callback=cancel_callback),
         fill_profile_and_submit=lambda: fill_profile_and_submit(log_callback=log_callback, cancel_callback=cancel_callback),

--- a/mail_service.py
+++ b/mail_service.py
@@ -258,10 +258,13 @@ def cloudflare_get_oai_code(
                 try:
                     detail = cloudflare_get_message_detail(api_base, dev_token, msg_id)
                     detail_body = normalize_mail_body(detail)
+                    detail_subject = str(detail.get("subject", "") or "")
                     if detail_body:
                         combined += "\n" + detail_body
+                    if detail_subject:
+                        combined += "\n" + detail_subject
                     if not subject:
-                        subject = str(detail.get("subject", "") or "")
+                        subject = detail_subject
                 except Exception as exc:
                     if log_callback:
                         log_callback(

--- a/mail_service.py
+++ b/mail_service.py
@@ -6,6 +6,7 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from curl_cffi import requests
+from registration_flow import VerificationCodeUnavailable
 
 DUCKMAIL_API_BASE = "https://api.duckmail.sbs"
 
@@ -15,6 +16,26 @@ YYDS_API_BASE = "https://maliapi.215.im/v1"
 config = {}
 _cf_domain_index = 0
 _cloudmail_domain_index = 0
+
+
+def _detail_retry_attempt(state, message_id, now=None):
+    """Return a 1-based detail-fetch attempt when due, otherwise 0.
+
+    A message is never permanently discarded merely because it has already
+    been inspected several times. Detail retries back off while the enclosing
+    mailbox timeout remains authoritative.
+    """
+    current = time.time() if now is None else float(now)
+    key = str(message_id)
+    record = state.setdefault(key, {"attempts": 0, "next_retry_at": 0.0})
+    if current < float(record.get("next_retry_at") or 0.0):
+        return 0
+    attempt = int(record.get("attempts") or 0) + 1
+    record["attempts"] = attempt
+    delay = min(15.0, 2.0 * (2 ** max(0, attempt - 1)))
+    record["next_retry_at"] = current + delay
+    return attempt
+
 _OWN_NAMES = {'cloudmail_get_email_and_token', 'get_messages', 'cloudflare_get_messages', 'get_yyds_api_key', 'yyds_generate_username', 'yyds_get_domains', 'yyds_get_email_and_token', 'yyds_get_oai_code', 'get_email_provider', 'cloudflare_get_domains', 'extract_verification_code', 'get_cloudflare_api_base', 'cloudflare_apply_auth_params', 'duckmail_get_oai_code', 'create_account', 'get_yyds_jwt', 'get_message_detail', 'yyds_create_account', 'get_duckmail_api_key', 'get_cloudflare_path', 'cloudflare_create_account', 'cloudflare_get_token', 'cloudflare_get_oai_code', 'get_cloudmail_public_token', 'generate_username', 'yyds_get_message_detail', 'cloudflare_next_default_domain', 'yyds_get_messages', 'yyds_get_token', 'get_domains', 'get_token', 'cloudflare_create_temp_address', 'get_cloudflare_api_key', 'get_cloudmail_path', 'get_cloudmail_api_base', 'cloudmail_get_oai_code', 'cloudflare_build_headers', 'cloudflare_is_admin_create_path', 'cloudmail_next_domain', 'cloudflare_get_message_detail', 'cloudmail_get_messages', 'get_user_agent', 'yyds_pick_domain', '_pick_list_payload', 'get_email_and_token', 'get_oai_code', 'get_cloudflare_auth_mode', 'pick_domain'}
 
 
@@ -188,8 +209,7 @@ def cloudflare_get_oai_code(
     if not api_base:
         raise Exception("Cloudflare API Base 未配置")
     deadline = time.time() + timeout
-    # 同一封邮件正文可能延迟可读，允许多次重试解析，避免偶发漏码
-    seen_attempts = {}
+    detail_retries = {}
     next_resend_at = time.time() + 35
     while time.time() < deadline:
         raise_if_cancelled(cancel_callback)
@@ -216,13 +236,8 @@ def cloudflare_get_oai_code(
             msg_id = msg.get("id") or msg.get("msgid")
             if not msg_id:
                 continue
-            attempt = int(seen_attempts.get(msg_id, 0))
-            if attempt >= 5:
-                continue
-            seen_attempts[msg_id] = attempt + 1
             recipients = [t.get("address", "").lower() for t in (msg.get("to") or [])]
             msg_addr = str(msg.get("address", "")).lower()
-            # 优先匹配目标邮箱；若结构不一致也允许继续解析，避免接口字段漂移导致漏码
             address_matched = True
             if recipients:
                 address_matched = email.lower() in recipients
@@ -232,20 +247,28 @@ def cloudflare_get_oai_code(
                 if log_callback:
                     log_callback(f"[Debug] 跳过疑似非目标邮件 id={msg_id} address={msg_addr} to={recipients}")
                 continue
-            # 先直接从列表项取内容，避免 detail 接口差异导致漏码
+
+            # Always inspect the latest list payload. Some providers fill the
+            # same message object in-place after the initial notification.
             subject = str(msg.get("subject", "") or "")
             combined = normalize_mail_body(msg)
-            # 再尝试 detail 接口补全内容
-            try:
-                detail = cloudflare_get_message_detail(api_base, dev_token, msg_id)
-                detail_body = normalize_mail_body(detail)
-                if detail_body:
-                    combined += "\n" + detail_body
-                if not subject:
-                    subject = str(detail.get("subject", "") or "")
-            except Exception as exc:
-                if log_callback:
-                    log_callback(f"[Debug] Cloudflare detail接口失败，改用列表内容解析: {exc}")
+
+            detail_attempt = _detail_retry_attempt(detail_retries, msg_id)
+            if detail_attempt:
+                try:
+                    detail = cloudflare_get_message_detail(api_base, dev_token, msg_id)
+                    detail_body = normalize_mail_body(detail)
+                    if detail_body:
+                        combined += "\n" + detail_body
+                    if not subject:
+                        subject = str(detail.get("subject", "") or "")
+                except Exception as exc:
+                    if log_callback:
+                        log_callback(
+                            f"[Debug] Cloudflare detail接口失败，保留列表内容继续等待: "
+                            f"id={msg_id} attempt={detail_attempt}: {exc}"
+                        )
+
             if log_callback:
                 log_callback(f"[Debug] Cloudflare 收到邮件: {subject}")
             code = extract_verification_code(combined, subject)
@@ -253,10 +276,11 @@ def cloudflare_get_oai_code(
                 if log_callback:
                     log_callback(f"[*] Cloudflare 从邮件中提取到验证码: {code}")
                 return code
-            elif log_callback:
-                log_callback(f"[Debug] 邮件已解析但未提取到验证码 id={msg_id} attempt={seen_attempts[msg_id]}")
+            if log_callback:
+                attempts = int(detail_retries.get(str(msg_id), {}).get("attempts") or 0)
+                log_callback(f"[Debug] 邮件已解析但未提取到验证码 id={msg_id} detail_attempts={attempts}")
         sleep_with_cancel(poll_interval, cancel_callback)
-    raise Exception(f"Cloudflare 在 {timeout}s 内未收到验证码邮件")
+    raise VerificationCodeUnavailable(f"Cloudflare 在 {timeout}s 内未收到验证码邮件")
 
 def cloudflare_get_token(api_base, address, password, api_key=None):
     headers = cloudflare_build_headers(content_type=True)
@@ -361,7 +385,6 @@ def cloudmail_get_oai_code(
     cancel_callback=None,
     resend_callback=None,
 ):
-    # dev_token 是为了保持现有邮箱 Provider 调用契约；Cloud Mail 使用配置中的公共 Token。
     _ = dev_token
     deadline = time.time() + timeout
     seen_attempts = {}
@@ -390,13 +413,8 @@ def cloudmail_get_oai_code(
             msg_id = msg.get("emailId") or msg.get("email_id") or msg.get("id")
             if not msg_id:
                 continue
-            attempt = int(seen_attempts.get(msg_id, 0))
-            if attempt >= 5:
-                continue
-            seen_attempts[msg_id] = attempt + 1
-            target_address = str(
-                msg.get("toEmail") or msg.get("to_email") or ""
-            ).strip().lower()
+            seen_attempts[msg_id] = int(seen_attempts.get(msg_id, 0)) + 1
+            target_address = str(msg.get("toEmail") or msg.get("to_email") or "").strip().lower()
             if target_address and target_address != email.lower():
                 continue
             code_value = str(msg.get("code", "") or "").strip()
@@ -417,7 +435,7 @@ def cloudmail_get_oai_code(
                     f"id={msg_id} attempt={seen_attempts[msg_id]}"
                 )
         sleep_with_cancel(poll_interval, cancel_callback)
-    raise Exception(f"Cloud Mail 在 {timeout}s 内未收到验证码邮件")
+    raise VerificationCodeUnavailable(f"Cloud Mail 在 {timeout}s 内未收到验证码邮件")
 
 def cloudmail_next_domain():
     """按配置轮换选择 Cloud Mail 无人收件域名。"""
@@ -455,7 +473,7 @@ def duckmail_get_oai_code(
     cancel_callback=None,
 ):
     deadline = time.time() + timeout
-    seen_attempts = {}
+    detail_retries = {}
     while time.time() < deadline:
         raise_if_cancelled(cancel_callback)
         try:
@@ -472,18 +490,26 @@ def duckmail_get_oai_code(
             recipients = [t.get("address", "").lower() for t in (msg.get("to") or [])]
             if email.lower() not in recipients:
                 continue
-            attempt = int(seen_attempts.get(msg_id, 0))
-            if attempt >= 5:
+
+            subject = str(msg.get("subject", "") or "")
+            combined = normalize_mail_body(msg)
+            code = extract_verification_code(combined, subject)
+            if code:
+                if log_callback:
+                    log_callback(f"[*] 从邮件列表中提取到验证码: {code}")
+                return code
+
+            detail_attempt = _detail_retry_attempt(detail_retries, msg_id)
+            if not detail_attempt:
                 continue
-            seen_attempts[msg_id] = attempt + 1
             try:
                 detail = get_message_detail(dev_token, msg_id)
             except Exception as exc:
                 if log_callback:
-                    log_callback(f"[Debug] 获取邮件详情失败: {exc}")
+                    log_callback(f"[Debug] 获取邮件详情失败 id={msg_id} attempt={detail_attempt}: {exc}")
                 continue
             combined = normalize_mail_body(detail)
-            subject = detail.get("subject", "")
+            subject = str(detail.get("subject", "") or "")
             if log_callback:
                 log_callback(f"[Debug] 收到邮件: {subject}")
             code = extract_verification_code(combined, subject)
@@ -492,7 +518,7 @@ def duckmail_get_oai_code(
                     log_callback(f"[*] 从邮件中提取到验证码: {code}")
                 return code
         sleep_with_cancel(poll_interval, cancel_callback)
-    raise Exception(f"在 {timeout}s 内未收到验证码邮件")
+    raise VerificationCodeUnavailable(f"在 {timeout}s 内未收到验证码邮件")
 
 def extract_verification_code(text, subject=""):
     if subject:
@@ -822,7 +848,7 @@ def yyds_get_oai_code(
     cancel_callback=None,
 ):
     deadline = time.time() + timeout
-    seen_attempts = {}
+    detail_retries = {}
     while time.time() < deadline:
         raise_if_cancelled(cancel_callback)
         try:
@@ -839,18 +865,26 @@ def yyds_get_oai_code(
             to_addrs = [t.get("address", "").lower() for t in (msg.get("to") or [])]
             if address.lower() not in to_addrs:
                 continue
-            attempt = int(seen_attempts.get(msg_id, 0))
-            if attempt >= 5:
+
+            subject = str(msg.get("subject", "") or "")
+            combined = normalize_mail_body(msg)
+            code = extract_verification_code(combined, subject)
+            if code:
+                if log_callback:
+                    log_callback(f"[*] YYDS 从邮件列表中提取到验证码: {code}")
+                return code
+
+            detail_attempt = _detail_retry_attempt(detail_retries, msg_id)
+            if not detail_attempt:
                 continue
-            seen_attempts[msg_id] = attempt + 1
             try:
                 detail = yyds_get_message_detail(msg_id, token=token, jwt=jwt)
             except Exception as exc:
                 if log_callback:
-                    log_callback(f"[Debug] YYDS 获取邮件详情失败: {exc}")
+                    log_callback(f"[Debug] YYDS 获取邮件详情失败 id={msg_id} attempt={detail_attempt}: {exc}")
                 continue
             combined = normalize_mail_body(detail)
-            subject = detail.get("subject", "")
+            subject = str(detail.get("subject", "") or "")
             if log_callback:
                 log_callback(f"[Debug] YYDS 收到邮件: {subject}")
             code = extract_verification_code(combined, subject)
@@ -859,7 +893,7 @@ def yyds_get_oai_code(
                     log_callback(f"[*] YYDS 从邮件中提取到验证码: {code}")
                 return code
         sleep_with_cancel(poll_interval, cancel_callback)
-    raise Exception(f"YYDS 在 {timeout}s 内未收到验证码邮件")
+    raise VerificationCodeUnavailable(f"YYDS 在 {timeout}s 内未收到验证码邮件")
 
 def yyds_get_token(address, api_key=None, jwt=None):
     key = api_key or get_yyds_api_key()

--- a/proxy_bridge.py
+++ b/proxy_bridge.py
@@ -385,11 +385,17 @@ def proxy_for_chromium(proxy):
     parsed = parse_proxy_url(raw)
     if not parsed or not parsed.hostname:
         return ""
+    scheme = (parsed.scheme or "http").lower()
+    if scheme == "socks4a":
+        raise ValueError("SOCKS4A requires prepare_chromium_proxy() to preserve remote DNS semantics")
+    if scheme == "socks5h":
+        # Chromium SOCKSv5 already resolves target hostnames through the proxy;
+        # its accepted configuration scheme is socks5:// rather than socks5h://.
+        scheme = "socks5"
     host = parsed.hostname
     if ":" in host and not host.startswith("["):
         host = "[%s]" % host
-    port = safe_proxy_port(parsed) or (443 if (parsed.scheme or "http").lower() == "https" else 1080 if (parsed.scheme or "").lower().startswith("socks") else 80)
-    scheme = parsed.scheme or "http"
+    port = safe_proxy_port(parsed) or (443 if scheme == "https" else 1080 if scheme.startswith("socks") else 80)
     return "%s://%s:%s" % (scheme, host, port)
 
 
@@ -401,10 +407,14 @@ def prepare_chromium_proxy(proxy, log=None):
     parsed = parse_proxy_url(raw)
     if not parsed or not parsed.hostname:
         raise ValueError("proxy URL is invalid")
-    if proxy_has_auth(raw):
+    scheme = (parsed.scheme or "http").lower()
+    if proxy_has_auth(raw) or scheme == "socks4a":
         bridge = LocalProxyBridge(raw)
         local_proxy = bridge.start()
-        logger("started authenticated proxy bridge: %s" % local_proxy)
+        if proxy_has_auth(raw):
+            logger("started authenticated proxy bridge: %s" % local_proxy)
+        else:
+            logger("started SOCKS4A compatibility proxy bridge: %s" % local_proxy)
         return local_proxy, bridge
     return proxy_for_chromium(raw), None
 

--- a/proxy_pool_v3.py
+++ b/proxy_pool_v3.py
@@ -273,6 +273,7 @@ class ProxyPoolManager:
         self.state_path = state_file if os.path.isabs(state_file) else os.path.join(_ROOT, state_file)
         self._lock = threading.RLock()
         self._condition = threading.Condition(self._lock)
+        self._refresh_lock = threading.Lock()
         self._nodes = {}
         self._probe_events = {}
         self._last_refresh = 0.0
@@ -473,9 +474,8 @@ class ProxyPoolManager:
             raise ProxyPoolError("代理池没有可用节点: %s" % detail)
         return unique
 
-    def reload_sources(self, force=False):
-        if not self.managed:
-            return self.snapshot()
+    def _reload_sources_locked(self, force=False):
+        """Refresh sources while the dedicated refresh lock is held."""
         now = time.time()
         with self._lock:
             if not force and self.refresh_interval > 0 and now - self._last_refresh < self.refresh_interval:
@@ -508,15 +508,33 @@ class ProxyPoolManager:
         self._save_state_file()
         return self.snapshot()
 
+    def reload_sources(self, force=False):
+        if not self.managed:
+            return self.snapshot()
+        with self._refresh_lock:
+            return self._reload_sources_locked(force=force)
+
     def refresh_if_due(self):
         if not self.managed:
             return
         now = time.time()
         with self._lock:
             due = self.refresh_interval > 0 and now - self._last_refresh >= self.refresh_interval
-        if due:
-            try: self.reload_sources(force=True)
-            except Exception as exc: self.log("[!] 代理池刷新失败，继续使用当前节点: %s" % safe_proxy_error_text(exc))
+        if not due or not self._refresh_lock.acquire(blocking=False):
+            return
+        try:
+            # Double-check after acquiring the refresh gate: another worker may
+            # have completed the refresh while this worker was scheduling.
+            now = time.time()
+            with self._lock:
+                due = self.refresh_interval > 0 and now - self._last_refresh >= self.refresh_interval
+            if not due:
+                return
+            self._reload_sources_locked(force=True)
+        except Exception as exc:
+            self.log("[!] 代理池刷新失败，继续使用当前节点: %s" % safe_proxy_error_text(exc))
+        finally:
+            self._refresh_lock.release()
 
     def _schedule_periodic_probe_if_due(self):
         if not self.managed or self.probe_interval <= 0:

--- a/registration_browser.py
+++ b/registration_browser.py
@@ -429,13 +429,21 @@ return !!(givenInput && familyInput && passwordInput);
     except Exception:
         return False
 
-def fill_email_and_submit(timeout=45, log_callback=None, cancel_callback=None):
+def fill_email_and_submit(timeout=45, log_callback=None, cancel_callback=None, on_mail_created=None):
     raise_if_cancelled(cancel_callback)
     email, dev_token = get_email_and_token()
     if not email or not dev_token:
         raise Exception("获取邮箱失败")
     if log_callback:
         log_callback(f"[*] 已创建邮箱: {email}")
+    if on_mail_created is not None:
+        try:
+            persisted = on_mail_created(email, dev_token)
+            if persisted is False and log_callback:
+                log_callback("[!] 邮箱凭据提前保存失败；注册继续，提交成功后还会再次尝试保存")
+        except Exception as exc:
+            if log_callback:
+                log_callback(f"[!] 邮箱凭据提前保存异常；注册继续，提交成功后还会再次尝试保存: {exc}")
     deadline = time.time() + timeout
     last_diag_time = 0
     last_reclick_time = 0
@@ -718,7 +726,7 @@ return 'enter';
         )
     raise Exception("未找到邮箱输入框或注册按钮")
 
-def fill_code_and_submit(email, dev_token, timeout=180, log_callback=None, cancel_callback=None):
+def fill_code_and_submit(email, dev_token, timeout=180, transition_timeout=15, log_callback=None, cancel_callback=None):
     def _resend_code():
         page.run_js(
             r"""
@@ -732,6 +740,7 @@ return false;
             """
         )
 
+    _mark_registration_stage("code_wait")
     code = get_oai_code(
         dev_token,
         email,
@@ -880,13 +889,39 @@ return 'clicked';
 
         if clicked == "clicked" or clicked == "no-button":
             if log_callback:
-                log_callback(f"[*] 已填写验证码并提交: {code}")
-            sleep_with_cancel(1.5, cancel_callback)
-            return code
+                if clicked == "clicked":
+                    log_callback(f"[*] 已填写验证码并触发提交，等待资料页确认: {code}")
+                else:
+                    log_callback(f"[*] 已填写验证码，页面未显示提交按钮，等待自动提交确认: {code}")
+            transition_deadline = min(deadline, time.time() + max(1.0, float(transition_timeout)))
+            while time.time() < transition_deadline:
+                raise_if_cancelled(cancel_callback)
+                if has_profile_form(log_callback=log_callback):
+                    if log_callback:
+                        log_callback("[*] 验证码提交已确认，资料页已出现")
+                    return code
+                rejection = page.run_js(
+                    r"""
+const text = (document.body ? document.body.innerText : '').replace(/\s+/g, ' ').toLowerCase();
+const markers = [
+  'invalid code', 'incorrect code', 'wrong code', 'code expired',
+  '验证码错误', '验证码无效', '验证码已过期', '验证码不正确'
+];
+return markers.find((item) => text.includes(item)) || '';
+                    """
+                )
+                if rejection:
+                    raise RuntimeError(f"验证码被页面明确拒绝: {rejection}")
+                sleep_with_cancel(0.5, cancel_callback)
+            from registration_flow import VerificationSubmissionUnconfirmed
+            raise VerificationSubmissionUnconfirmed(
+                f"验证码已填写，但在 {transition_timeout}s 内未确认进入资料页"
+            )
 
         sleep_with_cancel(0.5, cancel_callback)
 
-    raise Exception("验证码已获取，但自动填写/提交失败")
+    from registration_flow import VerificationSubmissionUnconfirmed
+    raise VerificationSubmissionUnconfirmed("验证码已获取，但自动填写/提交结果无法确认")
 
 def getTurnstileToken(log_callback=None, cancel_callback=None):
     global page

--- a/registration_browser.py
+++ b/registration_browser.py
@@ -900,16 +900,27 @@ return 'clicked';
                     if log_callback:
                         log_callback("[*] 验证码提交已确认，资料页已出现")
                     return code
-                rejection = page.run_js(
-                    r"""
+                try:
+                    rejection = page.run_js(
+                        r"""
 const text = (document.body ? document.body.innerText : '').replace(/\s+/g, ' ').toLowerCase();
 const markers = [
   'invalid code', 'incorrect code', 'wrong code', 'code expired',
   '验证码错误', '验证码无效', '验证码已过期', '验证码不正确'
 ];
 return markers.find((item) => text.includes(item)) || '';
-                    """
-                )
+                        """
+                    )
+                except (ContextLostError, JavaScriptError) as exc:
+                    # A navigation can invalidate the old execution context
+                    # just before the profile form becomes observable.
+                    if log_callback:
+                        log_callback(f"[Debug] 验证码提交后页面正在切换，继续等待: {exc}")
+                    try:
+                        refresh_active_page()
+                    except Exception:
+                        pass
+                    rejection = ""
                 if rejection:
                     raise RuntimeError(f"验证码被页面明确拒绝: {rejection}")
                 sleep_with_cancel(0.5, cancel_callback)

--- a/registration_flow.py
+++ b/registration_flow.py
@@ -23,6 +23,7 @@ STAGE_LEASE_ACQUIRE = "lease_acquire"
 STAGE_BROWSER_START = "browser_start"
 STAGE_PAGE_OPEN = "page_open"
 STAGE_EMAIL_SUBMIT = "email_submit"
+STAGE_CODE_WAIT = "code_wait"
 STAGE_CODE_SUBMIT = "code_submit"
 STAGE_PROFILE_SUBMIT = "profile_submit"
 STAGE_SSO_WAIT = "sso_wait"
@@ -49,6 +50,8 @@ def registration_retry_disposition(stage, error=None):
     stage = str(stage or STAGE_LEASE_ACQUIRE)
     if stage in (STAGE_LEASE_ACQUIRE, STAGE_BROWSER_START, STAGE_PAGE_OPEN):
         return SAFE_NEW_LEASE
+    if stage == STAGE_CODE_WAIT:
+        return SAME_LEASE_RECOVERY
     if stage in (STAGE_EMAIL_SUBMIT, STAGE_CODE_SUBMIT, STAGE_PROFILE_SUBMIT, STAGE_SSO_WAIT):
         return OUTCOME_UNCERTAIN
     if stage in (STAGE_ACCOUNT_CONFIRMED, STAGE_POSTPROCESS):
@@ -57,6 +60,16 @@ def registration_retry_disposition(stage, error=None):
 
 
 @dataclass
+class VerificationCodeUnavailable(RuntimeError):
+    """Mailbox polling timed out before any verification-code submission began."""
+    pass
+
+
+class VerificationSubmissionUnconfirmed(RuntimeError):
+    """A verification code was entered, but the browser could not confirm the next stage."""
+    pass
+
+
 class RegistrationCallbacks:
     log: Callable[[str], None]
     cancelled: Callable[[], bool]
@@ -177,15 +190,17 @@ def register_one_account(callbacks, ops, enable_nsfw=True, max_mail_retry=3):
         callbacks.log("[*] 3. 拉取验证码")
         try:
             if not ops.internal_stage_markers:
-                _set_registration_stage(STAGE_CODE_SUBMIT)
+                _set_registration_stage(STAGE_CODE_WAIT)
             code = ops.fill_code_and_submit(email, dev_token)
             mail_ok = True
             break
-        except Exception as exc:
-            message = str(exc)
-            if ("未收到验证码" in message or "验证码" in message) and mail_try < max_mail_retry and not is_proxy_transport_exception(exc):
-                callbacks.log(f"[!] 本邮箱未取到验证码，自动更换新邮箱重试: {message}")
-                _set_registration_stage(STAGE_BROWSER_START)
+        except VerificationCodeUnavailable as exc:
+            if mail_try < max_mail_retry:
+                callbacks.log(f"[!] 本邮箱在等待阶段未取到验证码，保持当前代理租约并更换邮箱重试: {exc}")
+                # Keep the code_wait disposition while recovering. If browser
+                # restart itself fails, the outer retry engine must not treat
+                # this as a safe point for acquiring a different proxy lease.
+                _set_registration_stage(STAGE_CODE_WAIT)
                 ops.restart_browser()
                 ops.sleep(1)
                 continue

--- a/registration_flow.py
+++ b/registration_flow.py
@@ -59,7 +59,6 @@ def registration_retry_disposition(stage, error=None):
     return OUTCOME_UNCERTAIN
 
 
-@dataclass
 class VerificationCodeUnavailable(RuntimeError):
     """Mailbox polling timed out before any verification-code submission began."""
     pass
@@ -70,6 +69,7 @@ class VerificationSubmissionUnconfirmed(RuntimeError):
     pass
 
 
+@dataclass
 class RegistrationCallbacks:
     log: Callable[[str], None]
     cancelled: Callable[[], bool]

--- a/registration_parallel.py
+++ b/registration_parallel.py
@@ -160,7 +160,9 @@ def run_parallel_batch(count, callbacks, observer, runtime_namespace, accounts_o
                 log_callback=worker_log, cancel_callback=combined_cancelled
             ),
             fill_email_and_submit=lambda: browser_module.fill_email_and_submit(
-                log_callback=worker_log, cancel_callback=combined_cancelled
+                log_callback=worker_log,
+                cancel_callback=combined_cancelled,
+                on_mail_created=save_mail,
             ),
             save_mail_credential=save_mail,
             fill_code_and_submit=lambda email, token: browser_module.fill_code_and_submit(

--- a/tests/test_audited_reliability_repairs.py
+++ b/tests/test_audited_reliability_repairs.py
@@ -228,7 +228,8 @@ class AuditedReliabilityRepairTests(unittest.TestCase):
 
         with patch.object(mail_service, "get_messages", return_value=[message]), \
              patch.object(mail_service, "get_message_detail", side_effect=detail), \
-             patch.object(mail_service, "sleep_with_cancel", side_effect=sleep), \
+             patch.object(mail_service, "raise_if_cancelled", return_value=None, create=True), \
+             patch.object(mail_service, "sleep_with_cancel", side_effect=sleep, create=True), \
              patch.object(mail_service.time, "time", side_effect=now):
             code = mail_service.duckmail_get_oai_code(
                 "token",

--- a/tests/test_audited_reliability_repairs.py
+++ b/tests/test_audited_reliability_repairs.py
@@ -1,0 +1,349 @@
+"""Regression coverage for the audited reliability repair set."""
+
+import queue
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import account_outputs
+import browser_runtime
+import grok_register_ttk as app
+import mail_service
+import proxy_bridge
+import registration_browser
+import registration_flow
+from app_config import DEFAULT_CONFIG
+from proxy_pool import ProxyPoolManager
+from registration_flow import (
+    OUTCOME_UNCERTAIN,
+    SAME_LEASE_RECOVERY,
+    STAGE_CODE_SUBMIT,
+    STAGE_CODE_WAIT,
+    RegistrationCallbacks,
+    RegistrationOperations,
+    VerificationSubmissionUnconfirmed,
+    registration_retry_disposition,
+    run_batch,
+)
+
+
+class Cancelled(Exception):
+    pass
+
+
+class RetryNeeded(Exception):
+    pass
+
+
+def _base_ops(fill_code, state=None):
+    state = state if state is not None else {}
+    return RegistrationOperations(
+        start_browser=lambda: None,
+        restart_browser=lambda: state.__setitem__("restarts", state.get("restarts", 0) + 1),
+        browser_missing=lambda: False,
+        open_signup_page=lambda: None,
+        fill_email_and_submit=lambda: ("user@example.com", "mail-token"),
+        save_mail_credential=lambda _email, _token: True,
+        fill_code_and_submit=fill_code,
+        fill_profile_and_submit=lambda: {
+            "given_name": "A",
+            "family_name": "B",
+            "password": "pw",
+        },
+        wait_for_sso_cookie=lambda: "sso-token",
+        enable_nsfw=lambda _sso: (True, "ok"),
+        persist_account_line=lambda *_args: None,
+        queue_unsaved_result=lambda *_args: True,
+        add_tokens=lambda *_args: {},
+        export_cpa=lambda *_args: {"ok": True, "skipped": False},
+        cleanup=lambda _reason: None,
+        sleep=lambda _seconds: None,
+        cancelled_exception=Cancelled,
+        retry_exception=RetryNeeded,
+        internal_stage_markers=True,
+    )
+
+
+class AuditedReliabilityRepairTests(unittest.TestCase):
+    def test_retry_disposition_distinguishes_code_wait_from_code_submit(self):
+        self.assertEqual(registration_retry_disposition(STAGE_CODE_WAIT), SAME_LEASE_RECOVERY)
+        self.assertEqual(registration_retry_disposition(STAGE_CODE_SUBMIT), OUTCOME_UNCERTAIN)
+
+    def test_verification_text_no_longer_triggers_mailbox_retry(self):
+        state = {"restarts": 0}
+
+        def fail_after_code_submit(_email, _token):
+            registration_flow._set_registration_stage(STAGE_CODE_SUBMIT)
+            raise RuntimeError("验证码已获取，但自动填写/提交失败")
+
+        callbacks = RegistrationCallbacks(log=lambda _message: None, cancelled=lambda: False)
+        ops = _base_ops(fail_after_code_submit, state)
+        begins = []
+
+        with patch("registration_flow.begin_registration_slot", side_effect=lambda **kw: begins.append(kw)), \
+             patch("registration_flow.end_registration_slot"), \
+             patch("registration_flow.current_proxy_lease", return_value=object()):
+            result = run_batch(
+                1,
+                callbacks,
+                lambda *_args: None,
+                ops,
+                enable_nsfw=False,
+                max_mail_retry=3,
+            )
+
+        self.assertEqual(len(begins), 1)
+        self.assertEqual(state["restarts"], 0)
+        self.assertEqual(result.fail_count, 1)
+        self.assertEqual(result.uncertain_count, 1)
+
+    def test_mail_credential_write_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertTrue(account_outputs.save_mail_credential(directory, "u@example.com", "token"))
+            self.assertTrue(account_outputs.save_mail_credential(directory, "u@example.com", "token"))
+            lines = (Path(directory) / "mail_credentials.txt").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(lines, ["u@example.com\ttoken"])
+
+    def test_mail_credential_is_persisted_before_email_submit_boundary(self):
+        events = []
+
+        class FakePage:
+            url = "https://accounts.x.ai/sign-up"
+
+            def run_js(self, script, *args):
+                if "const email = arguments[0]" in script:
+                    events.append("fill-email")
+                    return {"state": "filled", "url": self.url}
+                if "return (input.getAttribute('type')" in script:
+                    return True
+                if "const submitButton = buttons.find" in script:
+                    events.append("submit-dom")
+                    return "clicked"
+                raise AssertionError("unexpected JS path")
+
+        def mark(stage):
+            events.append("stage:" + stage)
+            return stage
+
+        with patch.object(registration_browser, "page", FakePage()), \
+             patch.object(registration_browser, "get_email_and_token", return_value=("u@example.com", "token"), create=True), \
+             patch.object(registration_browser, "raise_if_cancelled", return_value=None, create=True), \
+             patch.object(registration_browser, "sleep_with_cancel", return_value=None, create=True), \
+             patch.object(registration_browser, "_mark_registration_stage", side_effect=mark):
+            result = registration_browser.fill_email_and_submit(
+                timeout=2,
+                on_mail_created=lambda email, token: events.append("persist") or True,
+            )
+
+        self.assertEqual(result, ("u@example.com", "token"))
+        self.assertLess(events.index("persist"), events.index("stage:email_submit"))
+        self.assertLess(events.index("stage:email_submit"), events.index("submit-dom"))
+
+    def test_no_button_otp_requires_confirmed_page_transition(self):
+        markers = []
+
+        class FakePage:
+            def run_js(self, script, *args):
+                if "if (!code) return 'not-ready'" in script:
+                    return "aggregate"
+                if "function setInputValue" in script:
+                    return "filled-aggregate"
+                if "if (!btn) return 'no-button'" in script:
+                    return "no-button"
+                if "const markers = [" in script:
+                    return ""
+                raise AssertionError("unexpected JS path")
+
+        class Clock:
+            def __init__(self):
+                self.value = 0.0
+
+            def now(self):
+                self.value += 0.25
+                return self.value
+
+        clock = Clock()
+        with patch.object(registration_browser, "page", FakePage()), \
+             patch.object(registration_browser, "get_oai_code", return_value="ABC-123", create=True), \
+             patch.object(registration_browser, "raise_if_cancelled", return_value=None, create=True), \
+             patch.object(registration_browser, "sleep_with_cancel", return_value=None, create=True), \
+             patch.object(registration_browser, "has_profile_form", return_value=False), \
+             patch.object(registration_browser, "_mark_registration_stage", side_effect=lambda stage: markers.append(stage)), \
+             patch.object(registration_browser.time, "time", side_effect=clock.now):
+            with self.assertRaises(VerificationSubmissionUnconfirmed):
+                registration_browser.fill_code_and_submit(
+                    "u@example.com",
+                    "mail-token",
+                    timeout=5,
+                    transition_timeout=1,
+                )
+
+        self.assertIn(STAGE_CODE_WAIT, markers)
+        self.assertIn(STAGE_CODE_SUBMIT, markers)
+
+    def test_no_button_otp_can_succeed_after_auto_transition(self):
+        class FakePage:
+            def run_js(self, script, *args):
+                if "if (!code) return 'not-ready'" in script:
+                    return "aggregate"
+                if "function setInputValue" in script:
+                    return "filled-aggregate"
+                if "if (!btn) return 'no-button'" in script:
+                    return "no-button"
+                raise AssertionError("unexpected JS path")
+
+        with patch.object(registration_browser, "page", FakePage()), \
+             patch.object(registration_browser, "get_oai_code", return_value="ABC-123", create=True), \
+             patch.object(registration_browser, "raise_if_cancelled", return_value=None, create=True), \
+             patch.object(registration_browser, "sleep_with_cancel", return_value=None, create=True), \
+             patch.object(registration_browser, "has_profile_form", return_value=True), \
+             patch.object(registration_browser, "_mark_registration_stage"):
+            code = registration_browser.fill_code_and_submit(
+                "u@example.com",
+                "mail-token",
+                timeout=5,
+                transition_timeout=1,
+            )
+        self.assertEqual(code, "ABC-123")
+
+    def test_same_mail_message_can_be_retried_more_than_five_times(self):
+        message = {"id": "m1", "to": [{"address": "user@example.com"}]}
+        clock = {"now": 0.0}
+        calls = {"detail": 0}
+
+        def now():
+            return clock["now"]
+
+        def sleep(seconds, _cancel=None):
+            clock["now"] += max(float(seconds), 3.0)
+
+        def detail(_token, _message_id):
+            calls["detail"] += 1
+            if calls["detail"] <= 5:
+                return {"subject": "xAI verification"}
+            return {"subject": "ABC-123 xAI"}
+
+        with patch.object(mail_service, "get_messages", return_value=[message]), \
+             patch.object(mail_service, "get_message_detail", side_effect=detail), \
+             patch.object(mail_service, "sleep_with_cancel", side_effect=sleep), \
+             patch.object(mail_service.time, "time", side_effect=now):
+            code = mail_service.duckmail_get_oai_code(
+                "token",
+                "user@example.com",
+                timeout=100,
+                poll_interval=3,
+            )
+
+        self.assertEqual(code, "ABC-123")
+        self.assertGreaterEqual(calls["detail"], 6)
+
+    def test_chromium_normalizes_socks5h_and_bridges_socks4a(self):
+        self.assertEqual(
+            proxy_bridge.proxy_for_chromium("socks5h://127.0.0.1:1080"),
+            "socks5://127.0.0.1:1080",
+        )
+
+        class FakeBridge:
+            def __init__(self, raw):
+                self.raw = raw
+
+            def start(self):
+                return "http://127.0.0.1:32123"
+
+        with patch.object(proxy_bridge, "LocalProxyBridge", FakeBridge):
+            endpoint, bridge = proxy_bridge.prepare_chromium_proxy(
+                "socks4a://127.0.0.1:1080"
+            )
+        self.assertEqual(endpoint, "http://127.0.0.1:32123")
+        self.assertEqual(bridge.raw, "socks4a://127.0.0.1:1080")
+
+    def test_scheduled_proxy_refresh_is_single_flight(self):
+        cfg = dict(DEFAULT_CONFIG)
+        cfg.update({
+            "proxy_mode": "single",
+            "proxy": "http://127.0.0.1:8001",
+            "proxy_pool_refresh_interval_sec": 1,
+            "proxy_pool_probe_interval_sec": 0,
+        })
+        manager = ProxyPoolManager(cfg)
+        manager._last_refresh = 0.0
+        entered = threading.Event()
+        release = threading.Event()
+        calls = []
+
+        def fake_reload(force=False):
+            calls.append(force)
+            entered.set()
+            release.wait(2)
+            with manager._lock:
+                manager._last_refresh = time.time()
+            return manager.snapshot()
+
+        manager._reload_sources_locked = fake_reload
+        first = threading.Thread(target=manager.refresh_if_due)
+        second = threading.Thread(target=manager.refresh_if_due)
+        first.start()
+        self.assertTrue(entered.wait(1))
+        second.start()
+        second.join(1)
+        self.assertFalse(second.is_alive(), "second scheduled refresh should not wait on the refresh lock")
+        release.set()
+        first.join(2)
+        try:
+            self.assertEqual(calls, [True])
+        finally:
+            manager.shutdown()
+
+    def test_gui_registration_start_is_blocked_by_proxy_test(self):
+        gui = object.__new__(app.GrokRegisterGUI)
+        gui.operation_lock = threading.Lock()
+        gui.is_running = False
+        gui.registration_starting = False
+        gui.proxy_test_running = True
+        logs = []
+        gui.log = logs.append
+        gui.start_registration()
+        self.assertTrue(any("代理池测试进行中" in line for line in logs))
+
+    def test_gui_proxy_test_is_blocked_while_registration_is_reserved(self):
+        gui = object.__new__(app.GrokRegisterGUI)
+        gui.operation_lock = threading.Lock()
+        gui.is_running = False
+        gui.registration_starting = True
+        gui.proxy_test_running = False
+        logs = []
+        gui.log = logs.append
+        gui.test_proxy_pool()
+        self.assertTrue(any("启动或运行期间" in line for line in logs))
+
+    def test_gui_stats_and_yyds_controls_cover_new_fields(self):
+        gui = object.__new__(app.GrokRegisterGUI)
+        gui.ui_queue = queue.Queue()
+        gui.success_count = 1
+        gui.fail_count = 2
+        gui.uncertain_count = 1
+        gui.registered_unsaved_count = 3
+        gui.postprocess_warning_count = 4
+        gui.update_stats()
+        self.assertEqual(gui.ui_queue.get_nowait(), ("stats", 1, 2, 1, 3, 4))
+
+        source = Path(app.__file__).read_text(encoding="utf-8")
+        self.assertIn("self.yyds_api_key_var", source)
+        self.assertIn("self.yyds_jwt_var", source)
+        self.assertIn('config["yyds_api_key"] = self.yyds_api_key_var.get().strip()', source)
+        self.assertIn('config["yyds_jwt"] = self.yyds_jwt_var.get().strip()', source)
+
+    def test_legacy_extension_discovery_is_centralized_and_optional(self):
+        legacy = str(Path(browser_runtime.__file__).resolve().parent / "turnstilePatch")
+        with patch.object(browser_runtime, "_extension_path", ""), \
+             patch.object(browser_runtime.os.path, "isdir", side_effect=lambda path: str(path) == legacy):
+            self.assertEqual(browser_runtime._resolve_extension_path(), legacy)
+        with patch.object(browser_runtime.os.path, "isdir", return_value=False):
+            self.assertEqual(browser_runtime._resolve_extension_path(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cpa_core.py
+++ b/tests/test_cpa_core.py
@@ -1,7 +1,10 @@
 """验证 CPA 凭证结构、写入和核心 mint 流程。"""
 
+import base64
+import json
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,11 +14,41 @@ from cpa_xai.writer import write_cpa_xai_auth
 
 
 class CpaCoreTests(unittest.TestCase):
+    @staticmethod
+    def _jwt(payload):
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        encoded = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+        return "header.%s.signature" % encoded
+
     def test_schema_rejects_missing_tokens(self):
         with self.assertRaises(ValueError):
             build_cpa_xai_auth("a@example.com", "", "refresh")
         with self.assertRaises(ValueError):
             jwt_payload("not-a-jwt")
+
+    def test_explicit_access_token_ttl_controls_expired_timestamp(self):
+        now = 1_700_000_000
+        id_token = self._jwt({
+            "email": "user@example.com",
+            "sub": "subject",
+            "iat": now,
+            "exp": now + 86400,
+        })
+        with patch("cpa_xai.schema.time.time", return_value=now):
+            payload = build_cpa_xai_auth(
+                "user@example.com",
+                "opaque-access-token",
+                "refresh",
+                id_token=id_token,
+                expires_in=3600,
+            )
+        expected = datetime.fromtimestamp(now + 3600, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        id_expired = datetime.fromtimestamp(now + 86400, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self.assertEqual(payload["expires_in"], 3600)
+        self.assertEqual(payload["expired"], expected)
+        self.assertNotEqual(payload["expired"], id_expired)
+        self.assertEqual(payload["email"], "user@example.com")
+        self.assertEqual(payload["sub"], "subject")
 
     def test_writer_failure_does_not_leave_temp_file(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_minimal_boundary_regressions.py
+++ b/tests/test_minimal_boundary_regressions.py
@@ -88,20 +88,36 @@ class MinimalBoundaryRegressionTests(unittest.TestCase):
 
     def test_duckmail_retries_same_message_after_detail_failure(self):
         message = {"id": "m1", "to": [{"address": "user@example.com"}]}
+        clock = {"now": 0.0}
+
+        def now():
+            return clock["now"]
+
+        def sleep(seconds, _cancel=None):
+            clock["now"] += max(float(seconds), 2.0)
+
         with patch.object(mail_service, "get_messages", return_value=[message]), \
              patch.object(mail_service, "get_message_detail", side_effect=[RuntimeError("temporary"), {"subject": "ABC-123 xAI"}]), \
-             patch.object(mail_service, "sleep_with_cancel", return_value=None), \
-             patch.object(mail_service.time, "time", side_effect=[0, 0, 0]):
-            code = mail_service.duckmail_get_oai_code("token", "user@example.com", timeout=1, poll_interval=0)
+             patch.object(mail_service, "sleep_with_cancel", side_effect=sleep), \
+             patch.object(mail_service.time, "time", side_effect=now):
+            code = mail_service.duckmail_get_oai_code("token", "user@example.com", timeout=10, poll_interval=2)
         self.assertEqual(code, "ABC-123")
 
     def test_yyds_retries_same_message_after_detail_failure(self):
         message = {"id": "m1", "to": [{"address": "user@example.com"}]}
+        clock = {"now": 0.0}
+
+        def now():
+            return clock["now"]
+
+        def sleep(seconds, _cancel=None):
+            clock["now"] += max(float(seconds), 2.0)
+
         with patch.object(mail_service, "yyds_get_messages", return_value=[message]), \
              patch.object(mail_service, "yyds_get_message_detail", side_effect=[RuntimeError("temporary"), {"subject": "ABC-123 xAI"}]), \
-             patch.object(mail_service, "sleep_with_cancel", return_value=None), \
-             patch.object(mail_service.time, "time", side_effect=[0, 0, 0]):
-            code = mail_service.yyds_get_oai_code("token", "user@example.com", timeout=1, poll_interval=0)
+             patch.object(mail_service, "sleep_with_cancel", side_effect=sleep), \
+             patch.object(mail_service.time, "time", side_effect=now):
+            code = mail_service.yyds_get_oai_code("token", "user@example.com", timeout=10, poll_interval=2)
         self.assertEqual(code, "ABC-123")
 
     def test_pending_recovery_acquires_pending_and_target_locks_in_fixed_order(self):

--- a/tests/test_post_modularization_regressions.py
+++ b/tests/test_post_modularization_regressions.py
@@ -52,12 +52,19 @@ class PostModularizationRegressionTests(unittest.TestCase):
         gui = app.GrokRegisterGUI.__new__(app.GrokRegisterGUI)
         gui.success_count = 1
         gui.fail_count = 2
-        gui.registered_unsaved_count = 3
-        gui.postprocess_warning_count = 4
+        gui.uncertain_count = 3
+        gui.registered_unsaved_count = 4
+        gui.postprocess_warning_count = 5
         gui._reset_batch_counters()
         self.assertEqual(
-            (gui.success_count, gui.fail_count, gui.registered_unsaved_count, gui.postprocess_warning_count),
-            (0, 0, 0, 0),
+            (
+                gui.success_count,
+                gui.fail_count,
+                gui.uncertain_count,
+                gui.registered_unsaved_count,
+                gui.postprocess_warning_count,
+            ),
+            (0, 0, 0, 0, 0),
         )
 
     def test_cpa_hotload_requirement_only_applies_when_export_enabled(self):
@@ -96,6 +103,7 @@ class PostModularizationRegressionTests(unittest.TestCase):
         source = Path(browser_session.__file__).read_text(encoding="utf-8")
         self.assertNotIn("from grok_register_ttk", source)
         self.assertIn("from browser_runtime import create_browser_options", source)
+        self.assertNotIn("turnstilePatch", source)
 
     def test_browser_options_accept_explicit_extension_path(self):
         self.assertIn("extension_path", browser_runtime.create_browser_options.__code__.co_varnames)

--- a/tests/test_registration_proxy_lease.py
+++ b/tests/test_registration_proxy_lease.py
@@ -2,7 +2,12 @@ import unittest
 from unittest.mock import patch
 
 import registration_flow
-from registration_flow import RegistrationCallbacks, RegistrationOperations, run_batch
+from registration_flow import (
+    RegistrationCallbacks,
+    RegistrationOperations,
+    VerificationCodeUnavailable,
+    run_batch,
+)
 
 
 class Cancelled(Exception):
@@ -18,7 +23,7 @@ class RegistrationProxyLeaseTests(unittest.TestCase):
         def fill_code(_email, _token):
             state["code_calls"] += 1
             if state["code_calls"] == 1:
-                raise RuntimeError("未收到验证码")
+                raise VerificationCodeUnavailable("未收到验证码")
             return "123456"
 
         return RegistrationOperations(

--- a/tests/test_web_control_plane.py
+++ b/tests/test_web_control_plane.py
@@ -38,6 +38,7 @@ class WebControlPlaneTests(unittest.TestCase):
             })
             server._controller = None
             server._job_thread = None
+            server._maintenance_state = None
         with server._log_lock:
             server._logs.clear()
             server._log_seq = 0
@@ -106,6 +107,24 @@ class WebControlPlaneTests(unittest.TestCase):
         response = self.client.put("/api/config", json={"register_count": 2})
         self.assertEqual(response.status_code, 409)
 
+    def test_incomplete_yyds_config_can_be_saved_before_run(self):
+        cfg = self._base_config()
+        with patch.object(self.server.engine, "load_config", side_effect=self._fake_load(cfg)), patch.object(
+            self.server.engine, "save_config", return_value=None
+        ):
+            response = self.client.put(
+                "/api/config",
+                json={"email_provider": "yyds", "yyds_api_key": "", "yyds_jwt": ""},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["config"]["email_provider"], "yyds")
+
+    def test_config_update_is_rejected_during_maintenance(self):
+        with self.server._job_lock:
+            self.server._maintenance_state = "proxy_test"
+        response = self.client.put("/api/config", json={"register_count": 2})
+        self.assertEqual(response.status_code, 409)
+
     def test_proxy_pool_status_exposes_credentials(self):
         cfg = self._base_config()
         cfg.update({"proxy_mode": "single", "proxy": "http://secret:password@127.0.0.1:7890"})
@@ -123,6 +142,44 @@ class WebControlPlaneTests(unittest.TestCase):
             self.server._job_state["running"] = True
         self.assertEqual(self.client.post("/api/proxy-pool/reload").status_code, 409)
         self.assertEqual(self.client.post("/api/proxy-pool/test").status_code, 409)
+
+    def test_proxy_test_blocks_registration_start_for_full_probe_window(self):
+        cfg = self._base_config()
+        cfg.update({"proxy_mode": "single", "proxy": "http://127.0.0.1:7890"})
+        entered = threading.Event()
+        release = threading.Event()
+        responses = []
+
+        class BlockingManager:
+            def reload_sources(self, force=False):
+                return {"mode": "single", "managed": True, "nodes": []}
+
+            def probe_all(self, force=False):
+                entered.set()
+                release.wait(2)
+                return [{"id": "node", "status": "healthy"}]
+
+            def snapshot(self):
+                return {"mode": "single", "managed": True, "nodes": []}
+
+        with patch.object(self.server.engine, "load_config", side_effect=self._fake_load(cfg)), patch(
+            "proxy_pool.get_manager", return_value=BlockingManager()
+        ):
+            thread = threading.Thread(
+                target=lambda: responses.append(self.client.post("/api/proxy-pool/test")),
+                daemon=True,
+            )
+            thread.start()
+            self.assertTrue(entered.wait(1))
+            start_response = self.client.post("/api/start")
+            self.assertEqual(start_response.status_code, 409)
+            self.assertIn("proxy_test", start_response.json()["detail"])
+            release.set()
+            thread.join(2)
+
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(responses[0].status_code, 200)
+        self.assertIsNone(self.server._maintenance_state)
 
     def test_proxy_pool_reload_and_probe_use_shared_manager(self):
         cfg = self._base_config()

--- a/web/server.py
+++ b/web/server.py
@@ -25,6 +25,7 @@ app = FastAPI(title="grok-register WebUI", version="1.2")
 _job_lock = threading.Lock()
 _job_thread: Optional[threading.Thread] = None
 _controller: Any = None
+_maintenance_state: Optional[str] = None
 _job_state = {
     "running": False,
     "target": 0,
@@ -55,12 +56,34 @@ def _append_log(message: str) -> None:
 
 def _state_snapshot() -> dict[str, Any]:
     with _job_lock:
-        return dict(_job_state)
+        snapshot = dict(_job_state)
+        snapshot["maintenance"] = _maintenance_state
+        return snapshot
+
+
+def _begin_maintenance(kind: str) -> None:
+    global _maintenance_state
+    with _job_lock:
+        if _job_state["running"]:
+            raise HTTPException(status_code=409, detail="注册任务运行期间不能执行维护操作")
+        if _maintenance_state is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="已有维护操作正在执行: %s" % _maintenance_state,
+            )
+        _maintenance_state = str(kind)
+
+
+def _end_maintenance(kind: str) -> None:
+    global _maintenance_state
+    with _job_lock:
+        if _maintenance_state == str(kind):
+            _maintenance_state = None
 
 
 def _load_config_if_idle() -> dict[str, Any]:
     with _job_lock:
-        if not _job_state["running"]:
+        if not _job_state["running"] and _maintenance_state is None:
             engine.load_config()
         return dict(engine.config)
 
@@ -150,11 +173,13 @@ async def put_config(request: Request):
     with _job_lock:
         if _job_state["running"]:
             raise HTTPException(status_code=409, detail="任务运行期间不能修改配置")
+        if _maintenance_state is not None:
+            raise HTTPException(status_code=409, detail="维护操作期间不能修改配置")
         engine.load_config()
         candidate = dict(engine.config)
         candidate.update(updates)
         try:
-            validated = engine.validate_run_requirements(candidate)
+            validated = engine.validate_config_structure(candidate)
         except engine.ConfigError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         engine.config.clear()
@@ -174,9 +199,9 @@ def proxy_pool_status():
 @app.post("/api/proxy-pool/reload")
 def proxy_pool_reload():
     from proxy_pool import get_manager
-    with _job_lock:
-        if _job_state["running"]:
-            raise HTTPException(status_code=409, detail="任务运行期间不能重新加载代理池")
+    kind = "proxy_reload"
+    _begin_maintenance(kind)
+    try:
         engine.load_config()
         try:
             cfg = engine.validate_config_structure(dict(engine.config))
@@ -184,6 +209,8 @@ def proxy_pool_reload():
             snapshot = manager.reload_sources(force=True)
         except Exception as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        _end_maintenance(kind)
     _append_log("[*] 代理池已重新加载")
     return {"ok": True, **snapshot}
 
@@ -191,17 +218,19 @@ def proxy_pool_reload():
 @app.post("/api/proxy-pool/test")
 def proxy_pool_test():
     from proxy_pool import get_manager
-    with _job_lock:
-        if _job_state["running"]:
-            raise HTTPException(status_code=409, detail="任务运行期间不能手动测试代理池")
+    kind = "proxy_test"
+    _begin_maintenance(kind)
+    try:
         engine.load_config()
         try:
             cfg = engine.validate_config_structure(dict(engine.config))
             manager = get_manager(config=cfg, log=_append_log)
             manager.reload_sources(force=True)
+            results = manager.probe_all(force=True)
         except Exception as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-    results = manager.probe_all(force=True)
+    finally:
+        _end_maintenance(kind)
     _append_log("[*] 代理池测试完成: %s 个节点" % len(results))
     return {"ok": True, "results": results, **manager.snapshot()}
 
@@ -209,9 +238,9 @@ def proxy_pool_test():
 @app.post("/api/proxy-pool/preflight")
 def proxy_pool_preflight(node_id: str = Query(..., min_length=1)):
     from proxy_pool import get_manager
-    with _job_lock:
-        if _job_state["running"]:
-            raise HTTPException(status_code=409, detail="任务运行期间不能执行注册路径预检")
+    kind = "proxy_preflight"
+    _begin_maintenance(kind)
+    try:
         engine.load_config()
         try:
             cfg = engine.validate_config_structure(dict(engine.config))
@@ -223,6 +252,8 @@ def proxy_pool_preflight(node_id: str = Query(..., min_length=1)):
             raise
         except Exception as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        _end_maintenance(kind)
     _append_log("[*] 代理节点注册路径预检完成: %s" % node_id)
     return {"ok": True, "result": result, **manager.snapshot()}
 
@@ -247,6 +278,8 @@ def start():
     with _job_lock:
         if _job_state["running"]:
             raise HTTPException(status_code=409, detail="已有注册任务正在运行")
+        if _maintenance_state is not None:
+            raise HTTPException(status_code=409, detail="维护操作进行中，暂不能启动注册: %s" % _maintenance_state)
 
         engine.load_config()
         try:


### PR DESCRIPTION
## Scope

Implements the audited reliability repair plan for code issues 1–13.

- README is intentionally unchanged.
- CI/test-discovery issue #14 is intentionally excluded.
- No production feature files were deleted.

## Main changes

- Make verification retry decisions stage- and exception-type-aware; add an explicit code-wait state.
- Persist mailbox credentials before email submission and make persistence idempotent.
- Require a confirmed profile-page transition after OTP entry, including auto-submit/no-button paths.
- Replace the five-attempt mailbox-message cutoff with time-based retry/backoff.
- Serialize WebUI maintenance operations against registration start and allow staged structural config saves.
- Serialize GUI proxy tests against registration start in both directions; add YYDS credentials and uncertain-result stats.
- Normalize legacy Chromium SOCKS5H and bridge SOCKS4A to preserve DNS semantics.
- Serialize proxy-source refreshes with a dedicated single-flight refresh lock.
- Make CPA expiration fields describe the access-token lifetime consistently.
- Centralize optional legacy turnstilePatch discovery in browser_runtime.

## Regression coverage

Adds focused regressions for retry boundaries, early persistence, OTP transition confirmation, >5 mail-detail retries, reverse WebUI/GUI races, SOCKS handling, proxy refresh single-flight behavior, CPA expiry, YYDS GUI configuration, uncertain stats, and optional extension discovery.