### PR TITLE
Sync README and proxy docs with current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Grok Register 使用真实 Chromium / Chrome 完成注册流程，并把 GUI、C
 - 支持 **GUI / CLI / WebUI** 三种操作入口。
 - 支持可选 **1–8 线程并发注册**；默认关闭。
 - 支持 `direct / single / pool` 代理模式、健康检查、冷却、订阅、固定/旋转节点和账号级稳定 Proxy Lease。
-- 代理池可混合解析 **HTTP / HTTPS / SOCKS / VLESS / VMess / Trojan / Hysteria2 / TUIC** 节点。
+- 代理池可混合解析 **HTTP / HTTPS / SOCKS / VLESS / VMess / Trojan / Hysteria2 / TUIC / Shadowsocks** 节点。
 - 支持注册后尝试开启 NSFW；失败不会丢失已经注册成功的账号。
-- 支持 SSO 入库前筛查 `botFlagSource` / `policy=deny`；命中后隔离并跳过 grok2api / CPA。
+- 支持 SSO 入库前筛查 `botFlagSource` / `policy=deny`；明确命中后隔离并跳过 grok2api / CPA。风控检查采用 fail-open：网络请求失败、HTTP 异常或未解析到风控字段时会记录诊断并继续入库。
 - 支持把 SSO token 写入 grok2api 本地池或远端池。
 - 支持可选 CPA xAI OIDC 凭证导出与 CLIProxyAPI hotload。
-- 成功账号实时落盘；主结果写入失败时会进入 `*.pending.jsonl`，可稍后幂等恢复。
+- 成功账号实时落盘；主账号结果写入失败时会进入对应的 `accounts_*.txt.pending.jsonl`，可稍后幂等恢复。风控隔离写入失败使用独立的 risk pending，不与普通账号 pending 混用。
 - 支持停止任务、浏览器重启、邮箱重试、运行时清理和后处理错误隔离。
 
 单个账号的主要流程：
@@ -93,7 +93,7 @@ Grok Register 使用真实 Chromium / Chrome 完成注册流程，并把 GUI、C
 - Google Chrome 或 Chromium
 - 可访问注册页面和所选邮箱 API 的网络环境
 - GUI 需要 Tkinter；没有 Tkinter 时可以使用 CLI 或 WebUI
-- **仅当使用 VLESS / VMess / Trojan / Hysteria2 / TUIC 节点时需要 sing-box**；HTTP/SOCKS 继续使用项目原生代理实现
+- **仅当使用 VLESS / VMess / Trojan / Hysteria2 / TUIC / Shadowsocks 节点时需要 sing-box**；HTTP/HTTPS/SOCKS 继续使用项目原生代理实现
 
 ### 2. 安装
 
@@ -133,17 +133,23 @@ copy config.example.json config.json
 
 ### 3. 先完成最小配置
 
+如果先使用 DuckMail，可以从下面这组最小运行配置开始：
+
 ```json
 {
-  "email_provider": "cloudflare",
+  "email_provider": "duckmail",
+  "duckmail_api_key": "",
   "register_count": 1,
   "proxy_mode": "auto",
   "proxy": "",
-  "multi_thread_enabled": false
+  "multi_thread_enabled": false,
+  "cpa_export_enabled": false
 }
 ```
 
-然后根据 `email_provider` 填写对应邮箱配置。完整字段见 [`config.example.json`](config.example.json)。
+然后根据 `email_provider` 和需要启用的后处理功能继续填写对应配置。完整字段见 [`config.example.json`](config.example.json)。
+
+> `config.example.json` 是完整字段模板，其中的 `example.com`、`temp-mail.example.com` 等均为占位值，并不是可直接使用的服务地址。若使用 Cloudflare / Cloud Mail / YYDS，请先填写对应服务参数。
 
 ### 4. 启动
 
@@ -256,7 +262,7 @@ CLI 读取 `config.json`，通过校验后提示：
 | 配置项 | 说明 |
 | --- | --- |
 | `cloudflare_api_base` | 邮箱 API 根地址 |
-| `cloudflare_api_key` | 匿名模式留空；admin 模式填写 `ADMIN_PASSWORD` |
+| `cloudflare_api_key` | 与 `cloudflare_auth_mode` 配套使用的认证凭据：`none` 时可留空；`bearer` 时作为 Bearer Token；`x-api-key` 时作为 `X-API-Key`；`x-admin-auth` 时作为 Admin Password；`query-key` 时作为 URL `key` 参数 |
 | `cloudflare_auth_mode` | `none` / `bearer` / `x-api-key` / `x-admin-auth` / `query-key` |
 | `cloudflare_path_accounts` | 创建邮箱接口 |
 | `cloudflare_path_messages` | 邮件列表接口 |
@@ -340,7 +346,9 @@ Admin 创建示例：
   "proxy_pool_max_concurrent_per_node": 1,
   "proxy_protocol_backend": "auto",
   "proxy_singbox_path": "",
-  "proxy_protocol_start_timeout_sec": 10
+  "proxy_protocol_start_timeout_sec": 10,
+  "proxy_runtime_idle_ttl_sec": 120,
+  "proxy_runtime_cache_max": 32
 }
 ```
 
@@ -354,12 +362,13 @@ vmess://...
 trojan://...
 hysteria2://...
 tuic://...
+ss://...
 ```
 
 当前支持：
 
 - HTTP / HTTPS / SOCKS / SOCKS4 / SOCKS4A / SOCKS5 / SOCKS5H
-- VLESS / VMess / Trojan / Hysteria2 (`hy2`) / TUIC
+- VLESS / VMess / Trojan / Hysteria2 (`hy2`) / TUIC / Shadowsocks (`ss`)
 - 本地文件与 HTTP/HTTPS 订阅
 - 标准 Base64 与 URL-safe Base64 订阅
 - VLESS/VMess/Trojan 常见 TCP/WS/gRPC/HTTP/HTTPUpgrade/QUIC transport
@@ -367,9 +376,9 @@ tuic://...
 - 节点解析统计、健康探测、失败冷却和自动恢复
 - 固定/旋转入口、`{account}`、并发限制和账号级稳定 Proxy Lease
 
-高级协议采用 lazy runtime：只有节点实际被选中或测试时才启动 sing-box，并向现有注册流程提供 `http://127.0.0.1:<port>`；HTTP/SOCKS 节点不会启动 sing-box。没有活动 Lease 后对应 runtime 会停止。
+代理 runtime 采用 lazy + idle cache 机制：节点只有在实际被选中、probe 或 preflight 时才建立本地 runtime。需要统一 HTTP 出口的原生代理会使用 `LocalProxyBridge`；VLESS / VMess / Trojan / Hysteria2 / TUIC / Shadowsocks 使用 sing-box。Lease 引用数降为 0 后 runtime 默认不会立即退出，而是进入空闲缓存；默认 `proxy_runtime_idle_ttl_sec=120`、`proxy_runtime_cache_max=32`，TTL 到期、缓存淘汰或 Manager shutdown 时才会关闭。设置 `proxy_runtime_idle_ttl_sec=0` 可恢复零引用立即关闭。
 
-同一个账号 attempt 内，浏览器、邮箱、NSFW 和默认 CPA 保持同一个 Lease；邮箱重试不会中途更换代理。
+同一个账号 attempt 内，浏览器、邮箱、NSFW 和默认 CPA 保持同一个 Lease。等待验证码期间若确认尚未取得可用验证码，会在同一个 Lease 内更换邮箱重试；一旦进入验证码填写/提交阶段，后续异常不会再通过换邮箱或换代理重放注册，而会按“结果不确定”处理。
 
 完整参数、协议映射、运行时和健康度规则见 [`docs/proxy-pool.md`](docs/proxy-pool.md)。
 
@@ -431,7 +440,7 @@ tuic://...
 }
 ```
 
-两套远端凭据不能同时填写。远程地址要求 HTTPS；本机地址可以使用 HTTP。
+两套远端凭据不能同时填写。新版管理员账号/密码模式对非本机地址强制要求 HTTPS；`localhost` / `127.0.0.1` / `::1` 可以使用 HTTP。旧版 `app_key` 兼容接口当前接受 HTTP/HTTPS，但远程部署仍建议使用 HTTPS。
 
 ## CPA / xAI OIDC 导出
 
@@ -445,7 +454,11 @@ tuic://...
   "cpa_proxy": "",
   "cpa_headless": false,
   "cpa_force_standalone": true,
-  "cpa_mint_cookie_inject": true
+  "cpa_mint_timeout_sec": 300,
+  "cpa_mint_cookie_inject": true,
+  "cpa_oidc_request_timeout_sec": 15,
+  "cpa_oidc_poll_timeout_sec": 15,
+  "api_reverse_tools": ""
 }
 ```
 
@@ -459,12 +472,13 @@ tuic://...
 | 文件 / 目录 | 内容 |
 | --- | --- |
 | `accounts_*.txt` | 已成功保存的账号、密码和 SSO token |
-| `sso_risk_rejected.txt` | 被 `botFlagSource=1/2` 或 `policy=deny` 隔离的 SSO |
-| `mail_credentials.txt` | 临时邮箱地址与邮箱凭据 |
-| `*.pending.jsonl` | 已注册但主结果文件未成功写入的账号 |
-| 本地 `token.json` | 可选 grok2api 本地 token 池 |
-| `cpa_auths/xai-*.json` | 可选 CPA xAI OIDC 凭证 |
-| `cpa_auths/cpa_auth_failed.txt` | CPA 导出失败记录 |
+| `<sso_risk_rejected_file>` | 被 `botFlagSource=1/2` 或 `policy=deny` 隔离的 SSO；默认 `./sso_risk_rejected.txt` |
+| `mail_credentials.txt` | 注册过程中创建的临时邮箱地址与邮箱凭据；邮箱创建后会在提交注册前提前持久化，因此可能包含后续失败、重试或结果不确定 attempt 的记录 |
+| `accounts_*.txt.pending.jsonl` | 已注册成功但主账号结果文件未成功写入的普通账号 pending；可使用 `retry-pending` 恢复 |
+| `<sso_risk_rejected_file>.pending.jsonl` | 风控账号写入主隔离文件失败后的独立 risk pending；不要使用普通 `retry-pending` 恢复 |
+| `<grok2api_local_token_file>` | 可选 grok2api 本地 token 池；留空时默认项目目录下 `token.json` |
+| `<cpa_auth_dir>/xai-*.json` | 可选 CPA xAI OIDC 凭证；默认目录 `./cpa_auths` |
+| `<cpa_auth_dir>/cpa_auth_failed.txt` | CPA 导出失败记录 |
 | `screenshots/` | CPA 浏览器失败调试截图 |
 
 ### 恢复 pending
@@ -475,18 +489,22 @@ python grok_register_ttk.py retry-pending <pending文件> [输出文件]
 
 恢复过程使用文件锁、去重和原子替换，重复执行不会重复写入已经恢复成功的同一账号。
 
+> `retry-pending` **只用于普通账号结果 pending**（例如 `accounts_*.txt.pending.jsonl`），不适用于 `<sso_risk_rejected_file>.pending.jsonl`。风控 risk pending 是独立隔离队列，成功恢复后应进入配置的 `sso_risk_rejected_file`；当前没有对应的 CLI 子命令，内部恢复入口为 `sso_risk.retry_sso_risk_pending_file()`。
+
 ## 项目结构
 
 ```text
 .
 ├── grok_register_ttk.py       # GUI / CLI 入口与主适配层
-├── registration_flow.py       # 串行批量注册编排
-├── registration_parallel.py   # 可选多线程协调器
-├── registration_browser.py    # 主注册浏览器流程
-├── browser_runtime.py         # HTTP、Chromium options 与代理适配
-├── proxy_pool.py              # 代理池、健康度、Lease、订阅与探测
-├── proxy_protocols.py         # HTTP/SOCKS/VLESS/VMess/Trojan/HY2/TUIC 订阅解析
-├── proxy_protocol_runtime.py  # 高级协议 lazy sing-box → localhost HTTP 适配
+├── registration_flow.py       # GUI / CLI / WebUI 共用注册状态机、批量编排与阶段感知重试
+├── registration_parallel.py   # 可选多 worker 并发协调器
+├── registration_browser.py    # Chromium 注册页面状态与提交逻辑
+├── browser_runtime.py         # 共享 HTTP、Chromium Options 与代理注入
+├── proxy_pool.py              # proxy_pool_v3 的兼容导出层
+├── proxy_pool_v3.py           # 代理池核心：Source、Lease、健康度、冷却、刷新与 Probe
+├── proxy_bridge.py            # HTTP/HTTPS/SOCKS → localhost HTTP 代理桥与 Chromium 兼容
+├── proxy_protocols.py         # HTTP/SOCKS/VLESS/VMess/Trojan/HY2/TUIC/SS 订阅解析
+├── proxy_protocol_runtime.py  # Native bridge / sing-box lazy runtime 与 idle cache
 ├── mail_service.py            # 四种邮箱服务
 ├── app_config.py              # 默认配置、校验、加载与保存
 ├── account_outputs.py         # 账号、pending 与 token 输出
@@ -517,7 +535,7 @@ CLI 只是不启动 Tk GUI。注册页交互、验证码提交和 SSO cookie 获
 
 ### 为什么高级协议节点显示 unavailable？
 
-VLESS / VMess / Trojan / Hysteria2 / TUIC 需要本地 sing-box。默认从系统 `PATH` 查找，也可以在 WebUI / `config.json` 设置 `proxy_singbox_path`。HTTP/SOCKS 不受影响。
+VLESS / VMess / Trojan / Hysteria2 / TUIC / Shadowsocks 需要本地 sing-box。默认从系统 `PATH` 查找，也可以在 WebUI / `config.json` 设置 `proxy_singbox_path`。HTTP/HTTPS/SOCKS 不受影响。
 
 ### 为什么某些 V2Ray 订阅节点会被跳过？
 
@@ -545,7 +563,9 @@ WebUI 会显示订阅协议数量和解析错误。无法映射的 transport 或
 
 ### 为什么账号会进入 pending？
 
-表示注册已经完成，但主结果文件没有成功写入。使用 `retry-pending` 恢复即可，不需要重新注册。
+普通 `accounts_*.txt.pending.jsonl` 表示注册已经完成，但主账号结果文件没有成功写入；使用 `retry-pending` 恢复即可，不需要重新注册。
+
+如果是 `<sso_risk_rejected_file>.pending.jsonl`，则表示账号已经明确命中风控，但主隔离文件写入失败。这是独立 risk pending，不能使用普通 `retry-pending`。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ python grok_register_ttk.py retry-pending <pending文件> [输出文件]
 ├── account_outputs.py         # 账号、pending 与 token 输出
 ├── sso_risk.py                # SSO botFlag / policy 早停
 ├── cpa_export.py              # CPA/OIDC 导出入口
-├── cpa_xai/                   # CPA 浏览器、OAuth、代理桥与凭证写入
+├── cpa_xai/                   # CPA 浏览器、OAuth、代理辅助与凭证写入
 ├── web/
 │   ├── server.py              # FastAPI WebUI 控制层
 │   ├── index.html             # WebUI 页面

--- a/docs/proxy-pool.md
+++ b/docs/proxy-pool.md
@@ -5,7 +5,7 @@
 ## 核心原则
 
 - **一个账号 attempt 一个稳定租约**：浏览器、邮箱请求、注册阶段 HTTP、NSFW，以及未显式覆盖的 CPA/OIDC 共用同一个出口。
-- **安全重试优先于盲目重放**：只有尚未进行有状态提交的阶段才允许释放 Lease 后重新开始；邮箱、验证码、资料等提交之后发生传输错误会标记为结果不确定，不自动换代理重放整个注册流程。
+- **安全重试优先于盲目重放**：只有尚未进行有状态提交的阶段才允许释放 Lease 后重新开始；等待验证码但尚未开始验证码提交时，允许在同一个 Lease 内更换邮箱恢复。邮箱提交、验证码填写/提交、资料提交等有状态边界之后发生异常会标记为结果不确定，不自动换代理重放整个注册流程。
 - **所有 managed 网络组件消费统一 HTTP-compatible endpoint**：HTTP/SOCKS/高级协议最终都可被 Chromium、curl_cffi、urllib、CPA 和 probe 统一消费。
 - **Probe 与 Runtime Health 分离**：主动探测回答“现在能否连通”，业务健康回答“真实注册历史表现如何”。
 - **Fixed 与 Rotating 分离**：固定节点使用 Health/Failure/Cooldown；旋转入口统计出口成功/失败和成功率，不因为一次坏出口冷却整个 gateway。
@@ -102,6 +102,7 @@ lease_acquire
 browser_start
 page_open
 email_submit
+code_wait
 code_submit
 profile_submit
 sso_wait
@@ -116,16 +117,20 @@ lease_acquire / browser_start / page_open
 → SAFE_NEW_LEASE
 → 可以释放旧 Lease 后重新开始
 
+code_wait
+→ SAME_LEASE_RECOVERY
+→ 只允许保持当前 Lease，更换邮箱并重启浏览器后继续尝试
+
 email_submit / code_submit / profile_submit / sso_wait
 → OUTCOME_UNCERTAIN
-→ 不自动换代理重放整个注册流程
+→ 不自动换邮箱或换代理重放整个注册流程
 
 account_confirmed / postprocess
 → NO_RETRY
 → 已确认账号不重新注册
 ```
 
-这样可以避免“提交已可能被服务端接收，但本地读取响应时断线”后再次换 IP 重放，从而降低重复账号和重复提交风险。邮箱验证码重试仍在同一个账号 Lease 内完成。
+这样可以避免“提交已可能被服务端接收，但本地读取响应时断线”后再次换 IP 重放，从而降低重复账号和重复提交风险。只有在 `code_wait` 阶段确认没有取得可用验证码时，才会在同一个账号 Lease 内更换邮箱恢复；一旦进入 `code_submit`，后续提交结果无法确认时会计入结果不确定，不再通过邮箱重试绕过安全边界。
 
 WebUI 状态额外记录 `uncertain` 数量。
 


### PR DESCRIPTION
## Scope

Update documentation to match the current main-branch implementation.

Included:
- Shadowsocks support in README protocol lists and sing-box requirements.
- Runnable minimal DuckMail configuration and placeholder warning.
- Cloudflare auth-key semantics.
- Lazy runtime idle-cache lifecycle.
- Verification `code_wait` / same-lease recovery boundary.
- grok2api HTTPS behavior by remote auth mode.
- Complete CPA configuration example.
- Separate normal account pending from SSO-risk pending.
- Early mailbox credential persistence semantics.
- Configurable output paths.
- Current proxy module structure.
- SSO risk-gate fail-open behavior.
- `docs/proxy-pool.md` state-machine update.

Explicitly excluded per request:
- The README proxy badge/feature wording that omits `auto`.
- The existing README `user_agent` description.

No code or workflow files are changed.