### PR TITLE
Fix Drission JS concurrency failures for issue #81

### DIFF
--- a/registration_browser.py
+++ b/registration_browser.py
@@ -1,5 +1,6 @@
 """管理主注册浏览器生命周期并实现注册页面自动化操作。"""
 import gc
+import json
 import random
 import re
 import secrets
@@ -30,6 +31,24 @@ def _managed_proxy_mode():
         return str(config.get("proxy_mode", "auto") or "auto").strip().lower() in ("single", "pool")
     except Exception:
         return False
+
+
+def _is_pre_submit_js_transient(exc):
+    if isinstance(exc, (TimeoutError, ContextLostError, PageDisconnectedError)):
+        return True
+    if isinstance(exc, RuntimeError):
+        message = str(exc or "").lower()
+        return "js结果解析错误" in message or "js result parsing error" in message
+    return False
+
+
+def _run_pre_submit_js(script, *args):
+    try:
+        return page.run_js(script, *args)
+    except Exception as exc:
+        if _is_pre_submit_js_transient(exc):
+            raise AccountRetryNeeded(f"提交前浏览器 JS 暂时失败: {exc}") from exc
+        raise
 _OWN_NAMES = {'is_cloudflare_block_response', 'response_preview', 'start_browser', 'enable_nsfw_for_token', 'stop_browser_proxy_bridge', 'set_tos_accepted', 'fill_email_and_submit', 'getTurnstileToken', 'set_birth_date', 'generate_random_birthdate', 'fill_profile_and_submit', 'click_email_signup_button', 'wait_for_sso_cookie', 'fill_code_and_submit', 'build_profile', 'cleanup_runtime_memory', 'open_signup_page', 'stop_browser', 'encode_grpc_nsfw_settings', 'restart_browser', 'has_profile_form', 'update_nsfw_settings', 'refresh_active_page'}
 
 
@@ -307,7 +326,7 @@ def click_email_signup_button(timeout=10, log_callback=None, cancel_callback=Non
         if log_callback:
             log_callback("[Debug] 尝试查找“使用邮箱注册”按钮...")
 
-        clicked = page.run_js(r"""
+        clicked = _run_pre_submit_js(r"""
 function isVisible(node) {
     if (!node) return false;
     const style = window.getComputedStyle(node);
@@ -450,7 +469,7 @@ def fill_email_and_submit(timeout=45, log_callback=None, cancel_callback=None, o
     last_snapshot = None
     while time.time() < deadline:
         raise_if_cancelled(cancel_callback)
-        filled = page.run_js(
+        filled_raw = _run_pre_submit_js(
             """
 const email = arguments[0];
 function isVisible(node) {
@@ -510,13 +529,13 @@ const visibleActions = Array.from(document.querySelectorAll('button, a, [role="b
     .slice(0, 10);
 const input = emailCandidates().find((node) => isVisible(node) && !node.disabled && !node.readOnly) || null;
 if (!input) {
-    return {
+    return JSON.stringify({
         state: 'not-ready',
         url: location.href,
         title: document.title,
         inputs: visibleInputs,
         buttons: visibleActions,
-    };
+    });
 }
 input.focus(); input.click();
 const valueProto = input instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
@@ -530,30 +549,30 @@ input.dispatchEvent(new Event('change', { bubbles: true }));
 const inputType = (input.getAttribute('type') || '').toLowerCase();
 const isValid = inputType !== 'email' || input.checkValidity();
 if ((input.value || '').trim() !== email || !isValid) {
-    return {
+    return JSON.stringify({
         state: 'fill-failed',
         value: input.value || '',
         valid: isValid,
         input: describeInput(input),
         url: location.href,
-    };
+    });
 }
 input.blur();
-return {
+return JSON.stringify({
     state: 'filled',
     input: describeInput(input),
     url: location.href,
-};
+});
             """,
             email,
         )
-        state = filled.get("state") if isinstance(filled, dict) else filled
-        if isinstance(filled, dict):
-            last_snapshot = filled
+        filled = json.loads(filled_raw)
+        state = filled.get("state")
+        last_snapshot = filled
         if state == "not-ready":
             now = time.time()
             if now - last_reclick_time >= 3:
-                reclicked = page.run_js(r"""
+                reclicked = _run_pre_submit_js(r"""
 function isVisible(node) {
     if (!node) return false;
     const style = window.getComputedStyle(node);
@@ -595,9 +614,9 @@ return candidates[0].text || true;
                     log_callback(f"[Debug] 邮箱输入框未出现，已再次触发邮箱注册入口{detail}")
             if log_callback and now - last_diag_time >= 5:
                 last_diag_time = now
-                inputs = " | ".join((filled or {}).get("inputs", [])[:6]) if isinstance(filled, dict) else ""
-                buttons = " | ".join((filled or {}).get("buttons", [])[:8]) if isinstance(filled, dict) else ""
-                url = (filled or {}).get("url", page.url if page else "") if isinstance(filled, dict) else (page.url if page else "")
+                inputs = " | ".join((filled or {}).get("inputs", [])[:6])
+                buttons = " | ".join((filled or {}).get("buttons", [])[:8])
+                url = (filled or {}).get("url", page.url if page else "")
                 log_callback(f"[Debug] 等待邮箱输入框: url={url}; inputs={inputs or 'none'}; buttons={buttons or 'none'}")
             sleep_with_cancel(0.5, cancel_callback)
             continue
@@ -607,7 +626,7 @@ return candidates[0].text || true;
             sleep_with_cancel(0.5, cancel_callback)
             continue
         sleep_with_cancel(0.8, cancel_callback)
-        ready_to_submit = page.run_js(
+        ready_to_submit = _run_pre_submit_js(
             r"""
 function isVisible(node) {
     if (!node) return false;
@@ -939,7 +958,7 @@ def _read_turnstile_state():
     if page is None:
         return {"present": False, "token": "", "token_length": 0}
 
-    state = page.run_js(
+    state_raw = page.run_js(
         """
 try {
   const input = document.querySelector('input[name="cf-turnstile-response"]');
@@ -949,14 +968,16 @@ try {
   }
   const present = !!input
     || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey], script[src*="turnstile"]');
-  return { present, token, token_length: token.length };
+  return JSON.stringify({ present, token });
 } catch (e) {
-  return { present: false, token: '', token_length: 0 };
+  return JSON.stringify({ present: false, token: '' });
 }
         """
     )
-    if not isinstance(state, dict):
-        return {"present": False, "token": "", "token_length": 0}
+    try:
+        state = json.loads(state_raw)
+    except (TypeError, ValueError):
+        state = {}
     token = str(state.get("token") or "").strip()
     return {
         "present": bool(state.get("present")),

--- a/tests/test_audited_reliability_repairs.py
+++ b/tests/test_audited_reliability_repairs.py
@@ -1,5 +1,6 @@
 """Regression coverage for the audited reliability repair set."""
 
+import json
 import queue
 import tempfile
 import threading
@@ -116,7 +117,7 @@ class AuditedReliabilityRepairTests(unittest.TestCase):
             def run_js(self, script, *args):
                 if "const email = arguments[0]" in script:
                     events.append("fill-email")
-                    return {"state": "filled", "url": self.url}
+                    return json.dumps({"state": "filled", "url": self.url})
                 if "return (input.getAttribute('type')" in script:
                     return True
                 if "const submitButton = buttons.find" in script:

--- a/tests/test_drission_concurrency_regression.py
+++ b/tests/test_drission_concurrency_regression.py
@@ -1,0 +1,202 @@
+"""Regression coverage for DrissionPage JS concurrency failures (issue #81)."""
+
+import json
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import registration_browser
+from registration_flow import RegistrationCallbacks
+from registration_parallel import run_parallel_batch
+
+
+class RetryNeeded(Exception):
+    pass
+
+
+class Cancelled(Exception):
+    pass
+
+
+class DrissionConcurrencyRegressionTests(unittest.TestCase):
+    def test_pre_submit_timeout_becomes_safe_retry(self):
+        class FakePage:
+            def run_js(self, *_args):
+                raise TimeoutError("执行js超时（等待30秒）")
+
+        with patch.object(registration_browser, "page", FakePage()), patch.object(
+            registration_browser, "AccountRetryNeeded", RetryNeeded, create=True
+        ):
+            with self.assertRaises(RetryNeeded):
+                registration_browser._run_pre_submit_js("return true;")
+
+    def test_pre_submit_parser_error_becomes_safe_retry(self):
+        class FakePage:
+            def run_js(self, *_args):
+                raise RuntimeError("js结果解析错误。")
+
+        with patch.object(registration_browser, "page", FakePage()), patch.object(
+            registration_browser, "AccountRetryNeeded", RetryNeeded, create=True
+        ):
+            with self.assertRaises(RetryNeeded):
+                registration_browser._run_pre_submit_js("return true;")
+
+    def test_unexpected_runtime_error_is_not_hidden(self):
+        class FakePage:
+            def run_js(self, *_args):
+                raise RuntimeError("unexpected application bug")
+
+        with patch.object(registration_browser, "page", FakePage()), patch.object(
+            registration_browser, "AccountRetryNeeded", RetryNeeded, create=True
+        ):
+            with self.assertRaisesRegex(RuntimeError, "unexpected application bug"):
+                registration_browser._run_pre_submit_js("return true;")
+
+    def test_email_and_turnstile_use_primitive_json_transport(self):
+        source = Path(registration_browser.__file__).read_text(encoding="utf-8")
+        email = source[source.index("def fill_email_and_submit("):source.index("def fill_code_and_submit(")]
+        turnstile = source[source.index("def _read_turnstile_state("):source.index("def getTurnstileToken(")]
+
+        self.assertIn("filled_raw = _run_pre_submit_js(", email)
+        self.assertIn("filled = json.loads(filled_raw)", email)
+        self.assertGreaterEqual(email.count("return JSON.stringify({"), 3)
+        self.assertNotIn("return {\n        state:", email)
+        self.assertIn("return JSON.stringify({ present, token });", turnstile)
+        self.assertIn("state = json.loads(state_raw)", turnstile)
+
+    def test_submit_action_stays_outside_safe_retry_helper(self):
+        source = Path(registration_browser.__file__).read_text(encoding="utf-8")
+        email = source[source.index("def fill_email_and_submit("):source.index("def fill_code_and_submit(")]
+        stage = email.index('_mark_registration_stage("email_submit")')
+        submit = email.index("clicked = page.run_js(", stage)
+
+        self.assertLess(stage, submit)
+        self.assertNotIn("_run_pre_submit_js(", email[stage:])
+
+    def test_turnstile_json_string_decodes_without_remote_object(self):
+        class FakePage:
+            def run_js(self, *_args):
+                return json.dumps({"present": True, "token": "abc"})
+
+        with patch.object(registration_browser, "page", FakePage()):
+            state = registration_browser._read_turnstile_state()
+
+        self.assertEqual(
+            state,
+            {"present": True, "token": "abc", "token_length": 3},
+        )
+
+    def test_eight_workers_recover_independent_pre_submit_retries(self):
+        class FakeMail:
+            _OWN_NAMES = set()
+
+            def bind_runtime(self, _namespace):
+                return None
+
+        class FakeBrowser:
+            def __init__(self, worker_id):
+                self.worker_id = worker_id
+                self.browser = None
+                self.page = None
+                self.email_calls = 0
+
+            def bind_runtime(self, _namespace):
+                return None
+
+            def start_browser(self, log_callback=None):
+                self.browser = object()
+                self.page = object()
+
+            def restart_browser(self, log_callback=None, use_proxy=True):
+                self.stop_browser()
+                self.start_browser(log_callback=log_callback)
+
+            def stop_browser(self):
+                self.browser = None
+                self.page = None
+
+            def open_signup_page(self, **_kwargs):
+                return None
+
+            def fill_email_and_submit(self, **_kwargs):
+                self.email_calls += 1
+                if self.worker_id in (3, 6) and self.email_calls == 1:
+                    raise RetryNeeded("transient pre-submit JS failure")
+                return f"worker{self.worker_id}@example.com", "mail-token"
+
+            def fill_code_and_submit(self, _email, _token, **_kwargs):
+                return "123456"
+
+            def fill_profile_and_submit(self, **_kwargs):
+                return {"given_name": "Test", "family_name": "User", "password": "pw"}
+
+            def wait_for_sso_cookie(self, **_kwargs):
+                return f"sso-{self.worker_id}"
+
+            def enable_nsfw_for_token(self, _sso, **_kwargs):
+                return True, "ok"
+
+        modules = {}
+        module_lock = threading.Lock()
+
+        def fake_loader(path, module_name):
+            if Path(path).name == "mail_service.py":
+                return FakeMail()
+            worker_id = int(module_name.split("_worker_", 1)[1].split("_", 1)[0])
+            with module_lock:
+                module = FakeBrowser(worker_id)
+                modules[worker_id] = module
+            return module
+
+        persisted = []
+        persist_lock = threading.Lock()
+
+        def append_line(_path, email, _password, _sso):
+            with persist_lock:
+                persisted.append(email)
+
+        runtime_namespace = {
+            "_save_mail_credential": lambda *_args, **_kwargs: True,
+            "_append_account_line": append_line,
+            "_queue_unsaved_account": lambda *_args, **_kwargs: True,
+            "add_token_to_grok2api_pools": lambda *_args, **_kwargs: {},
+            "maybe_export_cpa_xai_after_success": lambda **_kwargs: {
+                "ok": False,
+                "skipped": True,
+                "reason": "disabled",
+            },
+            "sleep_with_cancel": lambda _seconds, cancel: (
+                (_ for _ in ()).throw(Cancelled()) if cancel() else None
+            ),
+            "RegistrationCancelled": Cancelled,
+            "AccountRetryNeeded": RetryNeeded,
+            "_screen_registered_sso": lambda *_args, **_kwargs: None,
+        }
+        callbacks = RegistrationCallbacks(log=lambda _message: None, cancelled=lambda: False)
+
+        with patch("registration_parallel.load_isolated_module", side_effect=fake_loader), patch(
+            "cpa_xai.browser_confirm.shutdown_mint_browsers", return_value=None
+        ):
+            result = run_parallel_batch(
+                count=8,
+                callbacks=callbacks,
+                observer=lambda *_args: None,
+                runtime_namespace=runtime_namespace,
+                accounts_output_file="unused.txt",
+                workers=8,
+                enable_nsfw=False,
+                cleanup_interval=0,
+                max_slot_retry=3,
+            )
+
+        self.assertEqual(result.processed_count, 8)
+        self.assertEqual(result.success_count, 8)
+        self.assertEqual(result.fail_count, 0)
+        self.assertEqual(len(persisted), 8)
+        self.assertEqual(modules[3].email_calls, 2)
+        self.assertEqual(modules[6].email_calls, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reliability_final_audit.py
+++ b/tests/test_reliability_final_audit.py
@@ -86,7 +86,7 @@ def test_sing_box_start_retries_after_early_exit_and_cleans_failed_config(monkey
 def test_strict_commit_boundaries_and_sso_exception_whitelist():
     source = pathlib.Path("registration_browser.py").read_text(encoding="utf-8")
     email = source[source.index("def fill_email_and_submit("):source.index("def fill_code_and_submit(")]
-    email_ready = email.index("ready_to_submit = page.run_js")
+    email_ready = email.index("ready_to_submit = _run_pre_submit_js")
     email_stage = email.index('_mark_registration_stage("email_submit")', email_ready)
     email_commit = email.index("clicked = page.run_js", email_stage)
     assert email_ready < email_stage < email_commit


### PR DESCRIPTION
Fixes #81 while keeping the existing DrissionPage/Chromium and parallel architecture unchanged.

Changes:
- return email/Turnstile state from JavaScript as JSON strings to avoid DrissionPage RemoteObject re-parsing
- convert only pre-submit Drission timeout/context/disconnect/parser failures into the existing safe slot retry
- keep the actual email-submit action outside the safe retry helper
- add focused regression coverage including an 8-worker recovery case

Intentionally unchanged:
- registration_parallel.py and registration_flow.py
- DrissionPage version and browser stack
- worker limit, proxy system, configuration, README/docs