### PR TITLE
Handle interactive Turnstile completion for issue #79

### DIFF
--- a/registration_browser.py
+++ b/registration_browser.py
@@ -986,7 +986,11 @@ try {
   const input = document.querySelector('input[name="cf-turnstile-response"]');
   let token = String((input && input.value) || '').trim();
   if (!token && window.turnstile && typeof window.turnstile.getResponse === 'function') {
-    token = String(window.turnstile.getResponse() || '').trim();
+    try {
+      token = String(window.turnstile.getResponse() || '').trim();
+    } catch (e) {
+      token = '';
+    }
   }
 
   const iframe = document.querySelector('iframe[src*="turnstile"]');

--- a/registration_browser.py
+++ b/registration_browser.py
@@ -999,7 +999,11 @@ try {
   const widgetPresent = !!input || !!iframe || !!widget;
   const visible = isVisible(iframe) || isVisible(widget);
 
-  const bodyText = String(document.body ? document.body.innerText : '').toLowerCase();
+  const nearbyText = [widget, iframe && iframe.parentElement, input && input.parentElement]
+    .filter(Boolean)
+    .map((node) => String(node.innerText || node.textContent || node.getAttribute?.('title') || ''))
+    .join(' ')
+    .toLowerCase();
   const failed = widgetPresent && [
     'verification failed',
     'challenge failed',
@@ -1007,7 +1011,7 @@ try {
     '验证失败',
     '验证已过期',
     '校验失败',
-  ].some((marker) => bodyText.includes(marker));
+  ].some((marker) => nearbyText.includes(marker));
 
   let state = 'ABSENT';
   if (token) state = 'SOLVED';
@@ -1207,16 +1211,6 @@ const submitBtn = buttons.find((node) => {
     return t.includes('完成注册') || t.includes('创建账户') || t.includes('signup') || t.includes('createaccount');
 });
 
-// 必须等待 Cloudflare 校验通过后再提交
-const cfInput = document.querySelector('input[name="cf-turnstile-response"]');
-const cfPresent = !!cfInput
-  || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey]');
-if (cfPresent) {
-    const token = String((cfInput && cfInput.value) || '').trim();
-    const solvedByToken = Boolean(token);
-    if (!solvedByToken) return 'wait-cloudflare:' + token.length;
-}
-
 if (submitBtn) {
     return 'ready-to-submit';
 }
@@ -1226,21 +1220,6 @@ return 'filled-no-submit';
                 family_name,
                 password,
             )
-
-            if isinstance(filled, str) and filled.startswith("wait-cloudflare"):
-                form_filled_once = True
-                token_len = filled.split(":", 1)[1] if ":" in filled else "0"
-                if log_callback:
-                    log_callback(
-                        f"[*] 资料已填写，等待 Cloudflare 人机验证通过... 当前token长度={token_len}"
-                    )
-                remaining = max(deadline - time.time(), 0.0)
-                getTurnstileToken(
-                    log_callback=log_callback,
-                    cancel_callback=cancel_callback,
-                    timeout=remaining,
-                )
-                continue
 
             if filled in ("ready-to-submit", "filled-no-submit"):
                 form_filled_once = True
@@ -1252,6 +1231,20 @@ return 'filled-no-submit';
                 sleep_with_cancel(0.5, cancel_callback)
                 continue
 
+        turnstile_state = _read_turnstile_state()
+        if turnstile_state["state"] in {
+            TURNSTILE_LOADING,
+            TURNSTILE_WAITING,
+            TURNSTILE_FAILED,
+        }:
+            remaining = max(deadline - time.time(), 0.0)
+            getTurnstileToken(
+                log_callback=log_callback,
+                cancel_callback=cancel_callback,
+                timeout=remaining,
+            )
+            continue
+
         submit_state = page.run_js(
             r"""
 function isVisible(node) {
@@ -1260,15 +1253,6 @@ function isVisible(node) {
     if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') return false;
     const rect = node.getBoundingClientRect();
     return rect.width > 0 && rect.height > 0;
-}
-
-const cfInput = document.querySelector('input[name="cf-turnstile-response"]');
-const cfPresent = !!cfInput
-  || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey]');
-if (cfPresent) {
-    const token = String((cfInput && cfInput.value) || '').trim();
-    const solvedByToken = Boolean(token);
-    if (!solvedByToken) return 'wait-cloudflare:' + token.length;
 }
 
 function buttonText(node) {
@@ -1294,20 +1278,6 @@ if (!submitBtn) {
 return 'ready-to-submit';
             """
         )
-
-        if isinstance(submit_state, str) and submit_state.startswith("wait-cloudflare"):
-            token_len = submit_state.split(":", 1)[1] if ":" in submit_state else "0"
-            if log_callback:
-                log_callback(
-                    f"[*] 等待 Cloudflare 人机验证通过后再提交... 当前token长度={token_len}"
-                )
-            remaining = max(deadline - time.time(), 0.0)
-            getTurnstileToken(
-                log_callback=log_callback,
-                cancel_callback=cancel_callback,
-                timeout=remaining,
-            )
-            continue
 
         if submit_state == "ready-to-submit":
             _mark_registration_stage("profile_submit")
@@ -1375,6 +1345,38 @@ def wait_for_sso_cookie(timeout=120, log_callback=None, cancel_callback=None):
             if now - last_submit_retry >= 2.5:
                 retried = page.run_js(
                     r"""
+const titleHit = !!Array.from(document.querySelectorAll('h1,h2,div,span')).find((el) => {
+    const t = (el.textContent || '').replace(/\s+/g, '');
+    const lower = t.toLowerCase();
+    return t.includes('完成注册') || lower.includes('completeyoursignup') || lower.includes('completesignup');
+});
+return titleHit ? 'final-page' : 'not-final-page';
+                    """
+                )
+
+                if retried == "final-page":
+                    turnstile_state = _read_turnstile_state()
+                    if turnstile_state["state"] in {
+                        TURNSTILE_LOADING,
+                        TURNSTILE_WAITING,
+                        TURNSTILE_FAILED,
+                    }:
+                        if log_callback:
+                            log_callback(
+                                f"[Debug] 最终页 Cloudflare 状态: {turnstile_state['state']}, "
+                                f"token长度={turnstile_state['token_length']}"
+                            )
+                        remaining = max(deadline - time.time(), 0.0)
+                        getTurnstileToken(
+                            log_callback=log_callback,
+                            cancel_callback=cancel_callback,
+                            timeout=remaining,
+                        )
+                        last_submit_retry = now
+                        continue
+
+                    retried = page.run_js(
+                        r"""
 function isVisible(node) {
     if (!node) return false;
     const style = window.getComputedStyle(node);
@@ -1382,22 +1384,6 @@ function isVisible(node) {
     const rect = node.getBoundingClientRect();
     return rect.width > 0 && rect.height > 0;
 }
-const titleHit = !!Array.from(document.querySelectorAll('h1,h2,div,span')).find((el) => {
-    const t = (el.textContent || '').replace(/\s+/g, '');
-    const lower = t.toLowerCase();
-    return t.includes('完成注册') || lower.includes('completeyoursignup') || lower.includes('completesignup');
-});
-if (!titleHit) return 'not-final-page';
-
-const cfInput = document.querySelector('input[name="cf-turnstile-response"]');
-const cfPresent = !!cfInput
-  || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey]');
-if (cfPresent) {
-    const token = String((cfInput && cfInput.value) || '').trim();
-    const solved = Boolean(token);
-    if (!solved) return 'final-page-wait-cf:' + token.length;
-}
-
 function buttonText(node) {
     return [
         node.innerText,
@@ -1421,8 +1407,8 @@ if (!submitBtn) {
 submitBtn.focus();
 submitBtn.click();
 return 'final-page-clicked-submit';
-                    """
-                )
+                        """
+                    )
                 last_submit_retry = now
                 if log_callback and (retried == "final-page-clicked-submit" or (isinstance(retried, str) and retried.startswith("final-page-no-submit"))):
                     log_callback(f"[Debug] 最终页状态: {retried}")
@@ -1437,19 +1423,6 @@ return 'final-page-clicked-submit';
                 else:
                     final_no_submit_state = ""
                     final_no_submit_since = None
-                if isinstance(retried, str) and retried.startswith("final-page-wait-cf"):
-                    token_len = retried.split(":", 1)[1] if ":" in retried else "0"
-                    if log_callback:
-                        log_callback(
-                            f"[Debug] 最终页等待 Cloudflare 人机验证, token长度={token_len}"
-                        )
-                    remaining = max(deadline - time.time(), 0.0)
-                    getTurnstileToken(
-                        log_callback=log_callback,
-                        cancel_callback=cancel_callback,
-                        timeout=remaining,
-                    )
-
 
             cookies = page.cookies(all_domains=True, all_info=True) or []
             for item in cookies:

--- a/registration_browser.py
+++ b/registration_browser.py
@@ -1016,14 +1016,15 @@ try {
   let state = 'ABSENT';
   if (token) state = 'SOLVED';
   else if (failed) state = 'FAILED';
-  else if (widgetPresent) state = 'WAITING';
-  else if (scriptPresent) state = 'LOADING';
+  else if (input || iframe) state = 'WAITING';
+  else if (widget) state = 'LOADING';
 
   return JSON.stringify({
     state,
     token,
     widget_present: widgetPresent,
     iframe_present: !!iframe,
+    script_present: scriptPresent,
     visible,
   });
 } catch (e) {
@@ -1032,6 +1033,7 @@ try {
     token: '',
     widget_present: false,
     iframe_present: false,
+    script_present: false,
     visible: false,
   });
 }
@@ -1062,6 +1064,7 @@ try {
         "token_length": len(token),
         "widget_present": bool(state.get("widget_present")),
         "iframe_present": bool(state.get("iframe_present")),
+        "script_present": bool(state.get("script_present")),
         "visible": bool(state.get("visible")),
     }
 

--- a/registration_browser.py
+++ b/registration_browser.py
@@ -19,6 +19,12 @@ browser_started_with_proxy = False
 cf_clearance = ""
 SIGNUP_URL = "https://accounts.x.ai/sign-up?redirect=grok-com"
 
+TURNSTILE_ABSENT = "ABSENT"
+TURNSTILE_LOADING = "LOADING"
+TURNSTILE_WAITING = "WAITING"
+TURNSTILE_SOLVED = "SOLVED"
+TURNSTILE_FAILED = "FAILED"
+
 
 def _mark_registration_stage(stage):
     # Function-local import avoids an import-time cycle while keeping the browser module reusable.
@@ -954,23 +960,72 @@ return markers.find((item) => text.includes(item)) || '';
     raise VerificationSubmissionUnconfirmed("验证码已获取，但自动填写/提交结果无法确认")
 
 def _read_turnstile_state():
-    """只读当前页面的 Turnstile 状态，不重置、不点击、不修改页面。"""
+    """只读 Turnstile 状态，不重置、不点击、不修改页面。"""
     if page is None:
-        return {"present": False, "token": "", "token_length": 0}
+        return {
+            "state": TURNSTILE_ABSENT,
+            "present": False,
+            "token": "",
+            "token_length": 0,
+            "widget_present": False,
+            "iframe_present": False,
+            "visible": False,
+        }
 
     state_raw = page.run_js(
         """
 try {
+  function isVisible(node) {
+    if (!node) return false;
+    const style = window.getComputedStyle(node);
+    if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') return false;
+    const rect = node.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
   const input = document.querySelector('input[name="cf-turnstile-response"]');
   let token = String((input && input.value) || '').trim();
   if (!token && window.turnstile && typeof window.turnstile.getResponse === 'function') {
     token = String(window.turnstile.getResponse() || '').trim();
   }
-  const present = !!input
-    || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey], script[src*="turnstile"]');
-  return JSON.stringify({ present, token });
+
+  const iframe = document.querySelector('iframe[src*="turnstile"]');
+  const widget = document.querySelector('div.cf-turnstile, [data-sitekey]');
+  const scriptPresent = !!document.querySelector('script[src*="turnstile"]');
+  const widgetPresent = !!input || !!iframe || !!widget;
+  const visible = isVisible(iframe) || isVisible(widget);
+
+  const bodyText = String(document.body ? document.body.innerText : '').toLowerCase();
+  const failed = widgetPresent && [
+    'verification failed',
+    'challenge failed',
+    'challenge expired',
+    '验证失败',
+    '验证已过期',
+    '校验失败',
+  ].some((marker) => bodyText.includes(marker));
+
+  let state = 'ABSENT';
+  if (token) state = 'SOLVED';
+  else if (failed) state = 'FAILED';
+  else if (widgetPresent) state = 'WAITING';
+  else if (scriptPresent) state = 'LOADING';
+
+  return JSON.stringify({
+    state,
+    token,
+    widget_present: widgetPresent,
+    iframe_present: !!iframe,
+    visible,
+  });
 } catch (e) {
-  return JSON.stringify({ present: false, token: '' });
+  return JSON.stringify({
+    state: 'ABSENT',
+    token: '',
+    widget_present: false,
+    iframe_present: false,
+    visible: false,
+  });
 }
         """
     )
@@ -978,16 +1033,33 @@ try {
         state = json.loads(state_raw)
     except (TypeError, ValueError):
         state = {}
+
     token = str(state.get("token") or "").strip()
+    status = str(state.get("state") or TURNSTILE_ABSENT).strip().upper()
+    if token:
+        status = TURNSTILE_SOLVED
+    if status not in {
+        TURNSTILE_ABSENT,
+        TURNSTILE_LOADING,
+        TURNSTILE_WAITING,
+        TURNSTILE_SOLVED,
+        TURNSTILE_FAILED,
+    }:
+        status = TURNSTILE_ABSENT
+
     return {
-        "present": bool(state.get("present")),
+        "state": status,
+        "present": status != TURNSTILE_ABSENT,
         "token": token,
         "token_length": len(token),
+        "widget_present": bool(state.get("widget_present")),
+        "iframe_present": bool(state.get("iframe_present")),
+        "visible": bool(state.get("visible")),
     }
 
 
-def getTurnstileToken(log_callback=None, cancel_callback=None, timeout=60):
-    """等待页面自身完成 Turnstile 验证并返回 response token。"""
+def _wait_for_turnstile(log_callback=None, cancel_callback=None, timeout=60):
+    """等待 Turnstile 自动完成或由用户在当前浏览器窗口完成。"""
     global page
     if page is None:
         raise Exception("页面未就绪，无法执行 Turnstile")
@@ -995,26 +1067,53 @@ def getTurnstileToken(log_callback=None, cancel_callback=None, timeout=60):
     timeout = max(float(timeout or 0), 0.0)
     deadline = time.time() + timeout
     started = time.time()
+    last_state = None
     last_log_at = 0.0
 
     while time.time() < deadline:
         raise_if_cancelled(cancel_callback)
         state = _read_turnstile_state()
+        status = state["state"]
         token = state["token"]
-        if token:
+
+        if status == TURNSTILE_SOLVED and token:
             if log_callback:
                 log_callback(f"[*] Cloudflare 人机验证已完成，token长度={len(token)}")
             return token
-        if not state["present"]:
+
+        if status == TURNSTILE_ABSENT:
             return ""
 
+        if status == TURNSTILE_FAILED:
+            raise Exception("Cloudflare 人机验证失败")
+
         now = time.time()
-        if log_callback and (last_log_at <= 0 or now - last_log_at >= 5):
-            log_callback(f"[*] 仍在等待 Cloudflare 人机验证... {int(now - started)}s")
+        state_changed = status != last_state
+        if log_callback and (state_changed or now - last_log_at >= 5):
+            if status == TURNSTILE_LOADING:
+                log_callback("[*] Cloudflare 人机验证组件正在加载...")
+            elif status == TURNSTILE_WAITING:
+                if state_changed:
+                    log_callback("[*] Cloudflare 人机验证等待完成，请在当前浏览器窗口完成验证")
+                else:
+                    log_callback(
+                        f"[*] 仍在等待 Cloudflare 人机验证... {int(now - started)}s"
+                    )
             last_log_at = now
+            last_state = status
+
         sleep_with_cancel(min(1.0, max(deadline - now, 0.0)), cancel_callback)
 
     raise Exception("Turnstile 验证超时")
+
+
+def getTurnstileToken(log_callback=None, cancel_callback=None, timeout=60):
+    """兼容入口：等待当前页面的 Turnstile 验证完成。"""
+    return _wait_for_turnstile(
+        log_callback=log_callback,
+        cancel_callback=cancel_callback,
+        timeout=timeout,
+    )
 
 def build_profile():
     given_name_pool = [
@@ -1107,7 +1206,7 @@ const submitBtn = buttons.find((node) => {
 // 必须等待 Cloudflare 校验通过后再提交
 const cfInput = document.querySelector('input[name="cf-turnstile-response"]');
 const cfPresent = !!cfInput
-  || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey], script[src*="turnstile"]');
+  || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey]');
 if (cfPresent) {
     const token = String((cfInput && cfInput.value) || '').trim();
     const solvedByToken = Boolean(token);
@@ -1161,7 +1260,7 @@ function isVisible(node) {
 
 const cfInput = document.querySelector('input[name="cf-turnstile-response"]');
 const cfPresent = !!cfInput
-  || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey], script[src*="turnstile"]');
+  || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey]');
 if (cfPresent) {
     const token = String((cfInput && cfInput.value) || '').trim();
     const solvedByToken = Boolean(token);
@@ -1288,7 +1387,7 @@ if (!titleHit) return 'not-final-page';
 
 const cfInput = document.querySelector('input[name="cf-turnstile-response"]');
 const cfPresent = !!cfInput
-  || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey], script[src*="turnstile"]');
+  || !!document.querySelector('iframe[src*="turnstile"], div.cf-turnstile, [data-sitekey]');
 if (cfPresent) {
     const token = String((cfInput && cfInput.value) || '').trim();
     const solved = Boolean(token);

--- a/registration_browser.py
+++ b/registration_browser.py
@@ -969,6 +969,7 @@ def _read_turnstile_state():
             "token_length": 0,
             "widget_present": False,
             "iframe_present": False,
+            "script_present": False,
             "visible": False,
         }
 

--- a/tests/test_drission_concurrency_regression.py
+++ b/tests/test_drission_concurrency_regression.py
@@ -62,7 +62,7 @@ class DrissionConcurrencyRegressionTests(unittest.TestCase):
         self.assertIn("filled = json.loads(filled_raw)", email)
         self.assertGreaterEqual(email.count("return JSON.stringify({"), 3)
         self.assertNotIn("return {\n        state:", email)
-        self.assertIn("return JSON.stringify({ present, token });", turnstile)
+        self.assertIn("return JSON.stringify({", turnstile)
         self.assertIn("state = json.loads(state_raw)", turnstile)
 
     def test_submit_action_stays_outside_safe_retry_helper(self):
@@ -77,15 +77,21 @@ class DrissionConcurrencyRegressionTests(unittest.TestCase):
     def test_turnstile_json_string_decodes_without_remote_object(self):
         class FakePage:
             def run_js(self, *_args):
-                return json.dumps({"present": True, "token": "abc"})
+                return json.dumps({
+                    "state": "SOLVED",
+                    "token": "abc",
+                    "widget_present": True,
+                    "iframe_present": False,
+                    "visible": True,
+                })
 
         with patch.object(registration_browser, "page", FakePage()):
             state = registration_browser._read_turnstile_state()
 
-        self.assertEqual(
-            state,
-            {"present": True, "token": "abc", "token_length": 3},
-        )
+        self.assertEqual(state["state"], registration_browser.TURNSTILE_SOLVED)
+        self.assertTrue(state["present"])
+        self.assertEqual(state["token"], "abc")
+        self.assertEqual(state["token_length"], 3)
 
     def test_eight_workers_recover_independent_pre_submit_retries(self):
         class FakeMail:

--- a/tests/test_turnstile_regression.py
+++ b/tests/test_turnstile_regression.py
@@ -24,6 +24,7 @@ def _state(status, token=""):
             registration_browser.TURNSTILE_FAILED,
         },
         "iframe_present": status == registration_browser.TURNSTILE_WAITING,
+        "script_present": status != registration_browser.TURNSTILE_ABSENT,
         "visible": status == registration_browser.TURNSTILE_WAITING,
     }
 
@@ -201,6 +202,7 @@ class TurnstileRegressionTests(unittest.TestCase):
                         "token": "",
                         "widget_present": True,
                         "iframe_present": True,
+                        "script_present": True,
                         "visible": True,
                     }
                 )
@@ -216,8 +218,11 @@ class TurnstileRegressionTests(unittest.TestCase):
 
     def test_final_sso_page_uses_same_turnstile_waiter(self):
         class FakePage:
+            def __init__(self):
+                self.states = iter(["final-page", "not-final-page"])
+
             def run_js(self, *_args):
-                return "final-page-wait-cf:0"
+                return next(self.states, "not-final-page")
 
             def cookies(self, **_kwargs):
                 return [{"name": "sso", "value": "sso-token"}]
@@ -228,12 +233,25 @@ class TurnstileRegressionTests(unittest.TestCase):
         ), patch.object(
             registration_browser, "raise_if_cancelled", return_value=None, create=True
         ), patch.object(
+            registration_browser,
+            "_read_turnstile_state",
+            return_value=_state(registration_browser.TURNSTILE_WAITING),
+        ), patch.object(
             registration_browser, "getTurnstileToken", waiter
         ):
             token = registration_browser.wait_for_sso_cookie(timeout=2)
 
         self.assertEqual(token, "sso-token")
         waiter.assert_called_once()
+
+    def test_script_only_is_not_treated_as_an_active_challenge(self):
+        source = Path(registration_browser.__file__).read_text(encoding="utf-8")
+        reader = source[
+            source.index("def _read_turnstile_state("):
+            source.index("def _wait_for_turnstile(")
+        ]
+        self.assertIn("else if (widget) state = 'LOADING';", reader)
+        self.assertNotIn("else if (scriptPresent) state = 'LOADING';", reader)
 
     def test_registration_path_contains_no_legacy_turnstile_interference(self):
         source = Path(registration_browser.__file__).read_text(encoding="utf-8")
@@ -248,6 +266,16 @@ class TurnstileRegressionTests(unittest.TestCase):
         self.assertNotIn("二次复用 Turnstile", source)
         self.assertNotIn("token.length >= 80", source)
         self.assertNotIn("nativeSetter.call(cfInput", source)
+
+        self.assertIn("_read_turnstile_state()", profile)
+        self.assertIn("getTurnstileToken(", profile)
+        self.assertIn("_read_turnstile_state()", sso)
+        self.assertIn("getTurnstileToken(", sso)
+
+        self.assertNotIn("cf-turnstile-response", profile)
+        self.assertNotIn("cf-turnstile-response", sso)
+        self.assertNotIn("wait-cloudflare", profile)
+        self.assertNotIn("final-page-wait-cf", sso)
         self.assertNotIn('script[src*="turnstile"]', profile)
         self.assertNotIn('script[src*="turnstile"]', sso)
 

--- a/tests/test_turnstile_regression.py
+++ b/tests/test_turnstile_regression.py
@@ -3,7 +3,7 @@
 import json
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import registration_browser
 
@@ -222,7 +222,7 @@ class TurnstileRegressionTests(unittest.TestCase):
             def cookies(self, **_kwargs):
                 return [{"name": "sso", "value": "sso-token"}]
 
-        waiter = unittest.mock.Mock(return_value="ready")
+        waiter = Mock(return_value="ready")
         with patch.object(registration_browser, "page", FakePage()), patch.object(
             registration_browser, "refresh_active_page", return_value=None
         ), patch.object(

--- a/tests/test_turnstile_regression.py
+++ b/tests/test_turnstile_regression.py
@@ -1,5 +1,6 @@
-"""Regression coverage for passive Turnstile waiting (issue #79)."""
+"""Regression coverage for Turnstile waiting and interactive completion (issue #79)."""
 
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -11,12 +12,28 @@ class Cancelled(Exception):
     pass
 
 
+def _state(status, token=""):
+    return {
+        "state": status,
+        "present": status != registration_browser.TURNSTILE_ABSENT,
+        "token": token,
+        "token_length": len(token),
+        "widget_present": status in {
+            registration_browser.TURNSTILE_WAITING,
+            registration_browser.TURNSTILE_SOLVED,
+            registration_browser.TURNSTILE_FAILED,
+        },
+        "iframe_present": status == registration_browser.TURNSTILE_WAITING,
+        "visible": status == registration_browser.TURNSTILE_WAITING,
+    }
+
+
 class TurnstileRegressionTests(unittest.TestCase):
     def test_existing_short_token_is_accepted_immediately(self):
         with patch.object(
             registration_browser,
             "_read_turnstile_state",
-            return_value={"present": True, "token": "ok", "token_length": 2},
+            return_value=_state(registration_browser.TURNSTILE_SOLVED, "ok"),
         ), patch.object(
             registration_browser, "raise_if_cancelled", return_value=None, create=True
         ), patch.object(registration_browser, "page", object()):
@@ -24,21 +41,19 @@ class TurnstileRegressionTests(unittest.TestCase):
 
         self.assertEqual(token, "ok")
 
-    def test_issue_79_waits_past_old_retry_threshold_without_reset(self):
+    def test_loading_can_finish_automatically(self):
         clock = {"now": 0.0}
         states = [
-            {"present": True, "token": "", "token_length": 0},
-            {"present": True, "token": "", "token_length": 0},
-            {"present": True, "token": "", "token_length": 0},
-            {"present": True, "token": "", "token_length": 0},
-            {"present": True, "token": "ready", "token_length": 5},
+            _state(registration_browser.TURNSTILE_LOADING),
+            _state(registration_browser.TURNSTILE_LOADING),
+            _state(registration_browser.TURNSTILE_SOLVED, "ready"),
         ]
 
         def now():
             return clock["now"]
 
         def sleep(_seconds, _cancel=None):
-            clock["now"] += 5.0
+            clock["now"] += 1.0
 
         with patch.object(
             registration_browser, "_read_turnstile_state", side_effect=states
@@ -51,12 +66,97 @@ class TurnstileRegressionTests(unittest.TestCase):
         ), patch.object(
             registration_browser, "page", object()
         ):
-            token = registration_browser.getTurnstileToken(timeout=30)
+            token = registration_browser.getTurnstileToken(timeout=10)
 
         self.assertEqual(token, "ready")
-        self.assertGreaterEqual(clock["now"], 15.0)
 
-    def test_turnstile_wait_times_out_deterministically(self):
+    def test_interactive_wait_can_finish_after_user_completion(self):
+        clock = {"now": 0.0}
+        logs = []
+        states = [
+            _state(registration_browser.TURNSTILE_WAITING),
+            _state(registration_browser.TURNSTILE_WAITING),
+            _state(registration_browser.TURNSTILE_WAITING),
+            _state(registration_browser.TURNSTILE_SOLVED, "ready"),
+        ]
+
+        def now():
+            return clock["now"]
+
+        def sleep(_seconds, _cancel=None):
+            clock["now"] += 2.0
+
+        with patch.object(
+            registration_browser, "_read_turnstile_state", side_effect=states
+        ), patch.object(
+            registration_browser, "raise_if_cancelled", return_value=None, create=True
+        ), patch.object(
+            registration_browser, "sleep_with_cancel", side_effect=sleep, create=True
+        ), patch.object(
+            registration_browser.time, "time", side_effect=now
+        ), patch.object(
+            registration_browser, "page", object()
+        ):
+            token = registration_browser.getTurnstileToken(
+                timeout=20,
+                log_callback=logs.append,
+            )
+
+        self.assertEqual(token, "ready")
+        self.assertTrue(any("请在当前浏览器窗口完成验证" in item for item in logs))
+
+    def test_absent_challenge_returns_to_page_re_evaluation(self):
+        with patch.object(
+            registration_browser,
+            "_read_turnstile_state",
+            return_value=_state(registration_browser.TURNSTILE_ABSENT),
+        ), patch.object(
+            registration_browser, "raise_if_cancelled", return_value=None, create=True
+        ), patch.object(registration_browser, "page", object()):
+            token = registration_browser.getTurnstileToken(timeout=5)
+
+        self.assertEqual(token, "")
+
+    def test_challenge_disappearing_while_waiting_returns_for_re_evaluation(self):
+        clock = {"now": 0.0}
+        states = [
+            _state(registration_browser.TURNSTILE_WAITING),
+            _state(registration_browser.TURNSTILE_ABSENT),
+        ]
+
+        def now():
+            return clock["now"]
+
+        def sleep(_seconds, _cancel=None):
+            clock["now"] += 1.0
+
+        with patch.object(
+            registration_browser, "_read_turnstile_state", side_effect=states
+        ), patch.object(
+            registration_browser, "raise_if_cancelled", return_value=None, create=True
+        ), patch.object(
+            registration_browser, "sleep_with_cancel", side_effect=sleep, create=True
+        ), patch.object(
+            registration_browser.time, "time", side_effect=now
+        ), patch.object(
+            registration_browser, "page", object()
+        ):
+            token = registration_browser.getTurnstileToken(timeout=5)
+
+        self.assertEqual(token, "")
+
+    def test_explicit_failed_state_stops_immediately(self):
+        with patch.object(
+            registration_browser,
+            "_read_turnstile_state",
+            return_value=_state(registration_browser.TURNSTILE_FAILED),
+        ), patch.object(
+            registration_browser, "raise_if_cancelled", return_value=None, create=True
+        ), patch.object(registration_browser, "page", object()):
+            with self.assertRaisesRegex(Exception, "Cloudflare 人机验证失败"):
+                registration_browser.getTurnstileToken(timeout=5)
+
+    def test_interactive_wait_times_out_deterministically(self):
         clock = {"now": 0.0}
 
         def now():
@@ -68,7 +168,7 @@ class TurnstileRegressionTests(unittest.TestCase):
         with patch.object(
             registration_browser,
             "_read_turnstile_state",
-            return_value={"present": True, "token": "", "token_length": 0},
+            return_value=_state(registration_browser.TURNSTILE_WAITING),
         ), patch.object(
             registration_browser, "raise_if_cancelled", return_value=None, create=True
         ), patch.object(
@@ -85,19 +185,71 @@ class TurnstileRegressionTests(unittest.TestCase):
         with patch.object(
             registration_browser,
             "_read_turnstile_state",
-            return_value={"present": True, "token": "", "token_length": 0},
+            return_value=_state(registration_browser.TURNSTILE_WAITING),
         ), patch.object(
             registration_browser, "raise_if_cancelled", side_effect=Cancelled(), create=True
         ), patch.object(registration_browser, "page", object()):
             with self.assertRaises(Cancelled):
                 registration_browser.getTurnstileToken(timeout=5)
 
+    def test_state_reader_distinguishes_interactive_widget(self):
+        class FakePage:
+            def run_js(self, *_args):
+                return json.dumps(
+                    {
+                        "state": "WAITING",
+                        "token": "",
+                        "widget_present": True,
+                        "iframe_present": True,
+                        "visible": True,
+                    }
+                )
+
+        with patch.object(registration_browser, "page", FakePage()):
+            state = registration_browser._read_turnstile_state()
+
+        self.assertEqual(state["state"], registration_browser.TURNSTILE_WAITING)
+        self.assertTrue(state["widget_present"])
+        self.assertTrue(state["iframe_present"])
+        self.assertTrue(state["visible"])
+        self.assertEqual(state["token_length"], 0)
+
+    def test_final_sso_page_uses_same_turnstile_waiter(self):
+        class FakePage:
+            def run_js(self, *_args):
+                return "final-page-wait-cf:0"
+
+            def cookies(self, **_kwargs):
+                return [{"name": "sso", "value": "sso-token"}]
+
+        waiter = unittest.mock.Mock(return_value="ready")
+        with patch.object(registration_browser, "page", FakePage()), patch.object(
+            registration_browser, "refresh_active_page", return_value=None
+        ), patch.object(
+            registration_browser, "raise_if_cancelled", return_value=None, create=True
+        ), patch.object(
+            registration_browser, "getTurnstileToken", waiter
+        ):
+            token = registration_browser.wait_for_sso_cookie(timeout=2)
+
+        self.assertEqual(token, "sso-token")
+        waiter.assert_called_once()
+
     def test_registration_path_contains_no_legacy_turnstile_interference(self):
         source = Path(registration_browser.__file__).read_text(encoding="utf-8")
+        profile = source[
+            source.index("def fill_profile_and_submit("):
+            source.index("def wait_for_sso_cookie(")
+        ]
+        sso = source[source.index("def wait_for_sso_cookie("):]
+
         self.assertNotIn("turnstile.reset", source)
         self.assertNotIn("MouseEvent.prototype", source)
         self.assertNotIn("二次复用 Turnstile", source)
         self.assertNotIn("token.length >= 80", source)
+        self.assertNotIn("nativeSetter.call(cfInput", source)
+        self.assertNotIn('script[src*="turnstile"]', profile)
+        self.assertNotIn('script[src*="turnstile"]', sso)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up fix for #79 while keeping the existing DrissionPage/Chromium architecture.

Changes:
- distinguish Turnstile ABSENT / LOADING / WAITING / SOLVED / FAILED states
- keep automatic challenges passive
- when an interactive challenge is waiting, keep the same browser/tab/proxy and prompt the user to complete it in the current browser window
- continue automatically once the real Turnstile response appears
- reuse the same waiter on the final SSO page
- stop treating a Turnstile API script alone as an instantiated challenge
- expand regression coverage for automatic, interactive, failure, timeout, disappearance, cancellation and final-page cases

Safety invariants retained:
- no turnstile.reset()
- no shadow-DOM/iframe challenge clicking
- no MouseEvent manipulation
- no token injection/write-back
- no browser restart, proxy switch or mailbox switch during the challenge

Intentionally unchanged:
- DrissionPage version/browser stack
- registration/proxy/concurrency architecture
- configuration and README