### PR TITLE
Fix Cloud Mail authentication handling for issue #84

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ Admin 创建示例：
 }
 ```
 
+Cloud Mail 的 Public Token 直接放在 `Authorization` 请求头中，不需要添加 `Bearer` 前缀。上游当前只保存一个全局 Public Token，因此重新生成 token 后旧 token 会失效。
+
+如果刚生成的新 token 暂时返回 `401 token验证失败`，请先确认 token 与 `cloudmail_api_base` 属于同一个 Cloud Mail 实例，并等待 Cloudflare Workers KV 同步后再试；不要连续重复生成 token。
+
 ## 代理与代理池
 
 默认：

--- a/grok_register_ttk.py
+++ b/grok_register_ttk.py
@@ -642,6 +642,11 @@ def _screen_registered_sso(sso, email, log_callback=None):
 
 def run_registration_common(count, log_callback, cancel_callback, accounts_output_file, observer):
     from registration_flow import RegistrationCallbacks, RegistrationOperations, run_batch
+
+    if str(config.get("email_provider", "") or "").strip().lower() == "cloudmail":
+        _bind_mail_service()
+        _mail_service.cloudmail_preflight(log_callback=log_callback)
+
     callbacks = RegistrationCallbacks(log=log_callback, cancelled=cancel_callback)
     parallel_enabled = bool(config.get("multi_thread_enabled", False))
     parallel_workers = int(config.get("multi_thread_workers", 4) or 4)

--- a/mail_service.py
+++ b/mail_service.py
@@ -18,6 +18,10 @@ _cf_domain_index = 0
 _cloudmail_domain_index = 0
 
 
+class CloudMailAuthError(RuntimeError):
+    """Cloud Mail public token is rejected by the configured instance."""
+
+
 def _detail_retry_attempt(state, message_id, now=None):
     """Return a 1-based detail-fetch attempt when due, otherwise 0.
 
@@ -36,7 +40,7 @@ def _detail_retry_attempt(state, message_id, now=None):
     record["next_retry_at"] = current + delay
     return attempt
 
-_OWN_NAMES = {'cloudmail_get_email_and_token', 'get_messages', 'cloudflare_get_messages', 'get_yyds_api_key', 'yyds_generate_username', 'yyds_get_domains', 'yyds_get_email_and_token', 'yyds_get_oai_code', 'get_email_provider', 'cloudflare_get_domains', 'extract_verification_code', 'get_cloudflare_api_base', 'cloudflare_apply_auth_params', 'duckmail_get_oai_code', 'create_account', 'get_yyds_jwt', 'get_message_detail', 'yyds_create_account', 'get_duckmail_api_key', 'get_cloudflare_path', 'cloudflare_create_account', 'cloudflare_get_token', 'cloudflare_get_oai_code', 'get_cloudmail_public_token', 'generate_username', 'yyds_get_message_detail', 'cloudflare_next_default_domain', 'yyds_get_messages', 'yyds_get_token', 'get_domains', 'get_token', 'cloudflare_create_temp_address', 'get_cloudflare_api_key', 'get_cloudmail_path', 'get_cloudmail_api_base', 'cloudmail_get_oai_code', 'cloudflare_build_headers', 'cloudflare_is_admin_create_path', 'cloudmail_next_domain', 'cloudflare_get_message_detail', 'cloudmail_get_messages', 'get_user_agent', 'yyds_pick_domain', '_pick_list_payload', 'get_email_and_token', 'get_oai_code', 'get_cloudflare_auth_mode', 'pick_domain'}
+_OWN_NAMES = {'cloudmail_build_headers', 'cloudmail_preflight', 'cloudmail_get_email_and_token', 'get_messages', 'cloudflare_get_messages', 'get_yyds_api_key', 'yyds_generate_username', 'yyds_get_domains', 'yyds_get_email_and_token', 'yyds_get_oai_code', 'get_email_provider', 'cloudflare_get_domains', 'extract_verification_code', 'get_cloudflare_api_base', 'cloudflare_apply_auth_params', 'duckmail_get_oai_code', 'create_account', 'get_yyds_jwt', 'get_message_detail', 'yyds_create_account', 'get_duckmail_api_key', 'get_cloudflare_path', 'cloudflare_create_account', 'cloudflare_get_token', 'cloudflare_get_oai_code', 'get_cloudmail_public_token', 'generate_username', 'yyds_get_message_detail', 'cloudflare_next_default_domain', 'yyds_get_messages', 'yyds_get_token', 'get_domains', 'get_token', 'cloudflare_create_temp_address', 'get_cloudflare_api_key', 'get_cloudmail_path', 'get_cloudmail_api_base', 'cloudmail_get_oai_code', 'cloudflare_build_headers', 'cloudflare_is_admin_create_path', 'cloudmail_next_domain', 'cloudflare_get_message_detail', 'cloudmail_get_messages', 'get_user_agent', 'yyds_pick_domain', '_pick_list_payload', 'get_email_and_token', 'get_oai_code', 'get_cloudflare_auth_mode', 'pick_domain'}
 
 
 def bind_runtime(namespace):
@@ -324,6 +328,62 @@ def cloudflare_next_default_domain():
     _cf_domain_index += 1
     return domain
 
+def cloudmail_build_headers():
+    """Build the official Cloud Mail public API headers.
+
+    maillab/cloud-mail expects the raw public token in Authorization, without
+    a Bearer prefix.
+    """
+    public_token = get_cloudmail_public_token()
+    if not public_token:
+        raise Exception("Cloud Mail Public Token 未配置")
+    return {
+        "Authorization": public_token,
+        "Content-Type": "application/json",
+    }
+
+
+def _cloudmail_auth_error_message():
+    return (
+        "Cloud Mail Public Token 验证失败。请确认 token 与 cloudmail_api_base 属于同一个 "
+        "Cloud Mail 实例；如果刚刚重新生成 token，请等待 Workers KV 同步后再试，"
+        "不要连续重新生成 token。"
+    )
+
+
+def _cloudmail_is_auth_failure(response, data=None):
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    if status_code == 401:
+        return True
+    if not isinstance(data, dict):
+        return False
+    result_code = data.get("code")
+    if result_code in (401, "401"):
+        return True
+    message = str(data.get("message") or "").strip().lower()
+    return message in {"token验证失败", "token validation failed"}
+
+
+def cloudmail_preflight(log_callback=None):
+    """Verify the configured public token before starting a browser session.
+
+    Only deterministic authentication failures stop startup. Transient network
+    or upstream availability errors are left to the normal mailbox polling
+    path so a preflight outage does not create a new hard dependency.
+    """
+    try:
+        cloudmail_get_messages("__grok_register_preflight__@invalid.local")
+    except CloudMailAuthError:
+        raise
+    except Exception as exc:
+        if log_callback:
+            log_callback(f"[!] Cloud Mail 鉴权预检暂时无法完成，将在实际邮件轮询时继续检查: {exc}")
+        return False
+    if log_callback:
+        log_callback("[*] Cloud Mail Public Token 预检通过")
+    return True
+
+
 def cloudmail_get_email_and_token():
     """生成无需预创建账号的 Cloud Mail 收件地址。"""
     if not get_cloudmail_api_base():
@@ -339,11 +399,11 @@ def cloudmail_get_email_and_token():
 
 def cloudmail_get_messages(address):
     api_base = get_cloudmail_api_base()
-    public_token = get_cloudmail_public_token()
     if not api_base:
         raise Exception("Cloud Mail API Base 未配置")
-    if not public_token:
+    if not get_cloudmail_public_token():
         raise Exception("Cloud Mail Public Token 未配置")
+
     payload = {
         "toEmail": address,
         "type": 0,
@@ -354,21 +414,28 @@ def cloudmail_get_messages(address):
     }
     resp = http_post(
         f"{api_base}{get_cloudmail_path()}",
-        headers={
-            "Authorization": public_token,
-            "Content-Type": "application/json",
-        },
+        headers=cloudmail_build_headers(),
         json=payload,
         timeout=20,
         replay_safe=True,
     )
-    resp.raise_for_status()
+
+    data = None
     try:
         data = resp.json()
     except Exception:
+        if _cloudmail_is_auth_failure(resp):
+            raise CloudMailAuthError(_cloudmail_auth_error_message())
+        resp.raise_for_status()
         raise Exception(f"Cloud Mail 邮件接口返回非JSON: {resp.text[:300]}")
+
+    if _cloudmail_is_auth_failure(resp, data):
+        raise CloudMailAuthError(_cloudmail_auth_error_message())
+
+    resp.raise_for_status()
     if not isinstance(data, dict):
         raise Exception(f"Cloud Mail 邮件接口返回格式错误: {data}")
+
     result_code = data.get("code")
     if result_code not in (None, 200, "200"):
         raise Exception(
@@ -405,6 +472,8 @@ def cloudmail_get_oai_code(
             next_resend_at = time.time() + 35
         try:
             messages = cloudmail_get_messages(email)
+        except CloudMailAuthError:
+            raise
         except Exception as exc:
             if log_callback:
                 log_callback(f"[Debug] Cloud Mail 拉取邮件列表失败: {exc}")

--- a/tests/test_cloudmail_auth.py
+++ b/tests/test_cloudmail_auth.py
@@ -1,0 +1,111 @@
+"""Regression coverage for Cloud Mail public-token authentication (issue #84)."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import grok_register_ttk as app
+import mail_service
+
+
+class DummyResponse:
+    def __init__(self, payload=None, status_code=200, text=""):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class CloudMailAuthTests(unittest.TestCase):
+    def setUp(self):
+        self.prev_mail_config = mail_service.config
+        self.prev_app_config = dict(app.config)
+        mail_service.config = {
+            "cloudmail_api_base": "https://mail.example.test",
+            "cloudmail_public_token": "public-token-123",
+            "cloudmail_domains": "example.test",
+            "cloudmail_path_messages": "/api/public/emailList",
+        }
+
+    def tearDown(self):
+        mail_service.config = self.prev_mail_config
+        app.config.clear()
+        app.config.update(self.prev_app_config)
+
+    def test_request_uses_raw_authorization_token_without_bearer(self):
+        response = DummyResponse({"code": 200, "data": []})
+        request = Mock(return_value=response)
+
+        with patch.object(mail_service, "http_post", request, create=True):
+            self.assertEqual(mail_service.cloudmail_get_messages("target@example.test"), [])
+
+        kwargs = request.call_args.kwargs
+        self.assertEqual(kwargs["headers"]["Authorization"], "public-token-123")
+        self.assertNotEqual(kwargs["headers"]["Authorization"], "Bearer public-token-123")
+        self.assertEqual(kwargs["headers"]["Content-Type"], "application/json")
+
+    def test_json_401_becomes_explicit_auth_error(self):
+        response = DummyResponse({"code": 401, "message": "token验证失败", "data": None})
+        with patch.object(mail_service, "http_post", return_value=response, create=True):
+            with self.assertRaises(mail_service.CloudMailAuthError):
+                mail_service.cloudmail_get_messages("target@example.test")
+
+    def test_http_401_becomes_explicit_auth_error(self):
+        response = DummyResponse(ValueError("not json"), status_code=401, text="unauthorized")
+        with patch.object(mail_service, "http_post", return_value=response, create=True):
+            with self.assertRaises(mail_service.CloudMailAuthError):
+                mail_service.cloudmail_get_messages("target@example.test")
+
+    def test_auth_error_is_not_retried_by_mail_polling(self):
+        auth_error = mail_service.CloudMailAuthError("bad token")
+        get_messages = Mock(side_effect=auth_error)
+        sleeper = Mock()
+
+        with patch.object(mail_service, "cloudmail_get_messages", get_messages), patch.object(
+            mail_service, "raise_if_cancelled", return_value=None, create=True
+        ), patch.object(mail_service, "sleep_with_cancel", sleeper, create=True):
+            with self.assertRaises(mail_service.CloudMailAuthError):
+                mail_service.cloudmail_get_oai_code(
+                    "unused",
+                    "target@example.test",
+                    timeout=180,
+                    poll_interval=3,
+                )
+
+        self.assertEqual(get_messages.call_count, 1)
+        sleeper.assert_not_called()
+
+    def test_preflight_propagates_auth_failure(self):
+        auth_error = mail_service.CloudMailAuthError("bad token")
+        with patch.object(mail_service, "cloudmail_get_messages", side_effect=auth_error):
+            with self.assertRaises(mail_service.CloudMailAuthError):
+                mail_service.cloudmail_preflight()
+
+    def test_registration_entry_runs_cloudmail_preflight_before_batch(self):
+        app.config["email_provider"] = "cloudmail"
+        auth_error = mail_service.CloudMailAuthError("bad token")
+
+        with patch.object(app, "_bind_mail_service", return_value=None), patch.object(
+            app._mail_service, "cloudmail_preflight", side_effect=auth_error
+        ) as preflight:
+            with self.assertRaises(mail_service.CloudMailAuthError):
+                app.run_registration_common(
+                    count=1,
+                    log_callback=lambda _message: None,
+                    cancel_callback=lambda: False,
+                    accounts_output_file="unused.txt",
+                    observer=lambda *_args: None,
+                )
+
+        preflight.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #84.

- keep the official raw `Authorization: <public token>` format
- classify HTTP/JSON 401 responses as a dedicated Cloud Mail auth error
- stop retrying deterministic auth failures in verification-code polling
- preflight Cloud Mail authentication before browser registration starts
- document single-token and Workers KV synchronization behavior
- add focused regression tests

Intentionally unchanged: browser/Turnstile, proxy pool, registration state machine, CPA, and dependencies.