### PR TITLE
Stabilize Cloud Mail auth handling for issue #86

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,9 @@ Admin 创建示例：
 
 Cloud Mail 的 Public Token 直接放在 `Authorization` 请求头中，不需要添加 `Bearer` 前缀。上游当前只保存一个全局 Public Token，因此重新生成 token 后旧 token 会失效。
 
-如果刚生成的新 token 暂时返回 `401 token验证失败`，请先确认 token 与 `cloudmail_api_base` 属于同一个 Cloud Mail 实例，并等待 Cloudflare Workers KV 同步后再试；不要连续重复生成 token。
+程序会在当前注册 slot / Proxy Lease 建立后、浏览器启动前使用同一个网络出口检查 Cloud Mail 鉴权。若遇到 `401 token验证失败`，会在同一出口内等待约 70 秒让 Workers KV 收敛，不会切换代理、自动生成新 token 或尝试其它鉴权格式。
+
+如果等待窗口结束后仍持续返回 401，请检查 `cloudmail_api_base`、Public Token，以及 Cloud Mail Worker 实际绑定的 KV namespace 是否属于同一部署实例；不要连续重复生成 token。错误日志只记录 token 长度和 SHA-256 短指纹，不会输出完整 Public Token。
 
 ## 代理与代理池
 

--- a/mail_service.py
+++ b/mail_service.py
@@ -1,8 +1,10 @@
 """接入临时邮箱服务并负责邮箱创建、邮件轮询和验证码提取。"""
+import hashlib
 import re
 import secrets
 import string
 import time
+import urllib.parse
 from typing import Any, Dict, List, Optional, Tuple
 
 from curl_cffi import requests
@@ -11,6 +13,7 @@ from registration_flow import VerificationCodeUnavailable
 DUCKMAIL_API_BASE = "https://api.duckmail.sbs"
 
 YYDS_API_BASE = "https://maliapi.215.im/v1"
+CLOUDMAIL_AUTH_CONVERGENCE_SECONDS = 70.0
 
 
 config = {}
@@ -40,7 +43,7 @@ def _detail_retry_attempt(state, message_id, now=None):
     record["next_retry_at"] = current + delay
     return attempt
 
-_OWN_NAMES = {'cloudmail_build_headers', 'cloudmail_preflight', 'cloudmail_get_email_and_token', 'get_messages', 'cloudflare_get_messages', 'get_yyds_api_key', 'yyds_generate_username', 'yyds_get_domains', 'yyds_get_email_and_token', 'yyds_get_oai_code', 'get_email_provider', 'cloudflare_get_domains', 'extract_verification_code', 'get_cloudflare_api_base', 'cloudflare_apply_auth_params', 'duckmail_get_oai_code', 'create_account', 'get_yyds_jwt', 'get_message_detail', 'yyds_create_account', 'get_duckmail_api_key', 'get_cloudflare_path', 'cloudflare_create_account', 'cloudflare_get_token', 'cloudflare_get_oai_code', 'get_cloudmail_public_token', 'generate_username', 'yyds_get_message_detail', 'cloudflare_next_default_domain', 'yyds_get_messages', 'yyds_get_token', 'get_domains', 'get_token', 'cloudflare_create_temp_address', 'get_cloudflare_api_key', 'get_cloudmail_path', 'get_cloudmail_api_base', 'cloudmail_get_oai_code', 'cloudflare_build_headers', 'cloudflare_is_admin_create_path', 'cloudmail_next_domain', 'cloudflare_get_message_detail', 'cloudmail_get_messages', 'get_user_agent', 'yyds_pick_domain', '_pick_list_payload', 'get_email_and_token', 'get_oai_code', 'get_cloudflare_auth_mode', 'pick_domain'}
+_OWN_NAMES = {'cloudmail_build_headers', 'cloudmail_preflight', 'cloudmail_wait_for_auth', 'cloudmail_get_email_and_token', 'get_messages', 'cloudflare_get_messages', 'get_yyds_api_key', 'yyds_generate_username', 'yyds_get_domains', 'yyds_get_email_and_token', 'yyds_get_oai_code', 'get_email_provider', 'cloudflare_get_domains', 'extract_verification_code', 'get_cloudflare_api_base', 'cloudflare_apply_auth_params', 'duckmail_get_oai_code', 'create_account', 'get_yyds_jwt', 'get_message_detail', 'yyds_create_account', 'get_duckmail_api_key', 'get_cloudflare_path', 'cloudflare_create_account', 'cloudflare_get_token', 'cloudflare_get_oai_code', 'get_cloudmail_public_token', 'generate_username', 'yyds_get_message_detail', 'cloudflare_next_default_domain', 'yyds_get_messages', 'yyds_get_token', 'get_domains', 'get_token', 'cloudflare_create_temp_address', 'get_cloudflare_api_key', 'get_cloudmail_path', 'get_cloudmail_api_base', 'cloudmail_get_oai_code', 'cloudflare_build_headers', 'cloudflare_is_admin_create_path', 'cloudmail_next_domain', 'cloudflare_get_message_detail', 'cloudmail_get_messages', 'get_user_agent', 'yyds_pick_domain', '_pick_list_payload', 'get_email_and_token', 'get_oai_code', 'get_cloudflare_auth_mode', 'pick_domain'}
 
 
 def bind_runtime(namespace):
@@ -343,11 +346,63 @@ def cloudmail_build_headers():
     }
 
 
-def _cloudmail_auth_error_message():
+def _cloudmail_token_warnings():
+    raw = str(config.get("cloudmail_public_token", "") or "")
+    token = raw.strip()
+    warnings = []
+    if raw != token:
+        warnings.append("Public Token 含有首尾空白，程序会去除这些空白")
+    if token.lower().startswith("bearer "):
+        warnings.append("Public Token 不应包含 Bearer 前缀")
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in ("'", '"'):
+        warnings.append("Public Token 不应包含包裹引号")
+    if token.startswith("{") or token.startswith("["):
+        warnings.append("Public Token 看起来像 JSON，而不是 token 本身")
+    return warnings
+
+
+def _cloudmail_network_label():
+    try:
+        from browser_runtime import get_configured_proxy
+        proxy = str(get_configured_proxy() or "").strip()
+    except Exception:
+        proxy = ""
+    if not proxy:
+        return "direct"
+    raw = proxy if "://" in proxy else "http://" + proxy
+    try:
+        parsed = urllib.parse.urlsplit(raw)
+        host = parsed.hostname or "unknown"
+        port = parsed.port
+        scheme = parsed.scheme or "proxy"
+        return f"{scheme}://{host}:{port}" if port else f"{scheme}://{host}"
+    except Exception:
+        return "proxy"
+
+
+def _cloudmail_auth_context():
+    token = get_cloudmail_public_token()
+    api_base = get_cloudmail_api_base()
+    try:
+        host = urllib.parse.urlsplit(api_base).netloc or api_base
+    except Exception:
+        host = api_base
+    fingerprint = hashlib.sha256(token.encode("utf-8")).hexdigest()[:8] if token else "none"
     return (
-        "Cloud Mail Public Token 验证失败。请确认 token 与 cloudmail_api_base 属于同一个 "
-        "Cloud Mail 实例；如果刚刚重新生成 token，请等待 Workers KV 同步后再试，"
-        "不要连续重新生成 token。"
+        f"host={host or 'unknown'} path={get_cloudmail_path()} "
+        f"token_len={len(token)} token_fp={fingerprint} network={_cloudmail_network_label()}"
+    )
+
+
+def _cloudmail_auth_error_message(persistent=False, elapsed=None):
+    if not persistent:
+        return "Cloud Mail Public Token 验证失败"
+    seconds = max(int(float(elapsed or 0)), 0)
+    return (
+        f"Cloud Mail Public Token 持续验证失败（约 {seconds}s）。当前请求中的 token 与该 Cloud Mail "
+        "实例保存的 Public Token 不一致；这已超过 Workers KV 收敛等待窗口。请检查 "
+        "cloudmail_api_base、Public Token，以及 Cloud Mail Worker 的 KV namespace 绑定。"
+        f" 诊断: {_cloudmail_auth_context()}"
     )
 
 
@@ -364,15 +419,89 @@ def _cloudmail_is_auth_failure(response, data=None):
     return message in {"token验证失败", "token validation failed"}
 
 
-def cloudmail_preflight(log_callback=None):
-    """Verify the configured public token before starting a browser session.
+def cloudmail_wait_for_auth(
+    address,
+    timeout=CLOUDMAIL_AUTH_CONVERGENCE_SECONDS,
+    log_callback=None,
+    cancel_callback=None,
+    initial_failure=False,
+):
+    """Wait briefly for Cloud Mail's singleton Workers KV token to converge.
 
-    Only deterministic authentication failures stop startup. Transient network
-    or upstream availability errors are left to the normal mailbox polling
-    path so a preflight outage does not create a new hard dependency.
+    Only 401/public-token failures are retried. The request keeps the current
+    network/proxy context; no proxy switching, token regeneration or auth
+    scheme fallback is attempted.
     """
+    timeout = max(float(timeout or 0), 0.0)
+    started = time.time()
+    deadline = started + timeout
+    offsets = (5.0, 15.0, 30.0, 60.0) if initial_failure else (0.0, 5.0, 15.0, 30.0, 60.0)
+    last_error = None
+    announced = False
+
+    for offset in offsets:
+        if offset > timeout:
+            break
+        wait_for = started + offset - time.time()
+        if wait_for > 0:
+            sleep_with_cancel(wait_for, cancel_callback)
+        raise_if_cancelled(cancel_callback)
+        try:
+            return cloudmail_get_messages(address)
+        except CloudMailAuthError as exc:
+            last_error = exc
+            if log_callback and not announced:
+                log_callback(
+                    "[!] Cloud Mail Public Token 暂时验证失败，将保持当前网络出口等待 Workers KV 收敛: "
+                    + _cloudmail_auth_context()
+                )
+                announced = True
+
+    if last_error is not None and time.time() < deadline:
+        sleep_with_cancel(max(deadline - time.time(), 0.0), cancel_callback)
+        raise_if_cancelled(cancel_callback)
+        try:
+            return cloudmail_get_messages(address)
+        except CloudMailAuthError as exc:
+            last_error = exc
+
+    if last_error is not None:
+        elapsed = max(time.time() - started, timeout)
+        raise CloudMailAuthError(
+            _cloudmail_auth_error_message(persistent=True, elapsed=elapsed)
+        ) from last_error
+
+    return cloudmail_get_messages(address)
+
+
+def cloudmail_preflight(
+    log_callback=None,
+    cancel_callback=None,
+    auth_timeout=CLOUDMAIL_AUTH_CONVERGENCE_SECONDS,
+    defer_until_slot=True,
+):
+    """Verify Cloud Mail auth in the same slot/network context as registration.
+
+    run_registration_common still calls this once for compatibility. That
+    early call is deliberately deferred; registration_flow performs the real
+    check after begin_registration_slot() and before browser startup.
+    """
+    if defer_until_slot:
+        if log_callback:
+            log_callback("[Debug] Cloud Mail 鉴权预检已延后到当前注册 slot / Proxy Lease 建立后")
+        return None
+
+    for warning in _cloudmail_token_warnings():
+        if log_callback:
+            log_callback(f"[!] Cloud Mail 配置提示: {warning}")
+
     try:
-        cloudmail_get_messages("__grok_register_preflight__@invalid.local")
+        cloudmail_wait_for_auth(
+            "__grok_register_preflight__@invalid.local",
+            timeout=auth_timeout,
+            log_callback=log_callback,
+            cancel_callback=cancel_callback,
+        )
     except CloudMailAuthError:
         raise
     except Exception as exc:
@@ -380,7 +509,7 @@ def cloudmail_preflight(log_callback=None):
             log_callback(f"[!] Cloud Mail 鉴权预检暂时无法完成，将在实际邮件轮询时继续检查: {exc}")
         return False
     if log_callback:
-        log_callback("[*] Cloud Mail Public Token 预检通过")
+        log_callback(f"[*] Cloud Mail Public Token 预检通过: {_cloudmail_auth_context()}")
     return True
 
 
@@ -459,6 +588,7 @@ def cloudmail_get_oai_code(
     deadline = time.time() + timeout
     seen_attempts = {}
     next_resend_at = time.time() + 35
+    auth_recovery_used = False
     while time.time() < deadline:
         raise_if_cancelled(cancel_callback)
         if resend_callback and time.time() >= next_resend_at:
@@ -473,7 +603,19 @@ def cloudmail_get_oai_code(
         try:
             messages = cloudmail_get_messages(email)
         except CloudMailAuthError:
-            raise
+            if auth_recovery_used:
+                raise
+            remaining = max(deadline - time.time(), 0.0)
+            if remaining <= 0:
+                raise
+            auth_recovery_used = True
+            messages = cloudmail_wait_for_auth(
+                email,
+                timeout=min(CLOUDMAIL_AUTH_CONVERGENCE_SECONDS, remaining),
+                log_callback=log_callback,
+                cancel_callback=cancel_callback,
+                initial_failure=True,
+            )
         except Exception as exc:
             if log_callback:
                 log_callback(f"[Debug] Cloud Mail 拉取邮件列表失败: {exc}")

--- a/registration_flow.py
+++ b/registration_flow.py
@@ -348,6 +348,20 @@ def _run_batch_legacy(settings, callbacks, observer, ops):
     return result
 
 
+def _preflight_cloudmail_after_lease(callbacks):
+    if str(app_config.get("email_provider", "") or "").strip().lower() != "cloudmail":
+        return True
+    # Local import avoids the registration_flow <-> mail_service import cycle.
+    # run_registration_common binds this module before run_batch(); the HTTP
+    # runtime then observes the current thread's Proxy Lease.
+    import mail_service
+    return mail_service.cloudmail_preflight(
+        log_callback=callbacks.log,
+        cancel_callback=callbacks.cancelled,
+        defer_until_slot=False,
+    )
+
+
 def _run_batch_managed(settings, callbacks, observer, ops):
     result = BatchResult(); retry_count_for_slot = 0; last_cleanup_success_count = 0; first_browser_start = True
     try:
@@ -358,6 +372,7 @@ def _run_batch_managed(settings, callbacks, observer, ops):
             _set_registration_stage(STAGE_LEASE_ACQUIRE)
             try:
                 begin_registration_slot(slot_index=slot_index, attempt_index=attempt_index, worker_key=threading.current_thread().name, log=callbacks.log, cancel_callback=callbacks.cancelled)
+                _preflight_cloudmail_after_lease(callbacks)
                 _set_registration_stage(STAGE_BROWSER_START)
                 if first_browser_start or ops.browser_missing():
                     ops.start_browser(); callbacks.log("[*] 浏览器已启动"); first_browser_start = False

--- a/registration_flow.py
+++ b/registration_flow.py
@@ -97,6 +97,7 @@ class RegistrationOperations:
     retry_exception: type
     internal_stage_markers: bool = False
     screen_sso: Optional[Callable[[str, str], Any]] = None
+    preflight_mail: Optional[Callable[[], Any]] = None
 
 
 @dataclass
@@ -348,12 +349,14 @@ def _run_batch_legacy(settings, callbacks, observer, ops):
     return result
 
 
-def _preflight_cloudmail_after_lease(callbacks):
+def _preflight_mail_after_lease(callbacks, ops):
+    preflight = getattr(ops, "preflight_mail", None)
+    if callable(preflight):
+        return preflight()
     if str(app_config.get("email_provider", "") or "").strip().lower() != "cloudmail":
         return True
-    # Local import avoids the registration_flow <-> mail_service import cycle.
-    # run_registration_common binds this module before run_batch(); the HTTP
-    # runtime then observes the current thread's Proxy Lease.
+    # Backward-compatible fallback for callers that have not injected the
+    # mail operation yet. Parallel workers always inject their isolated module.
     import mail_service
     return mail_service.cloudmail_preflight(
         log_callback=callbacks.log,
@@ -372,7 +375,7 @@ def _run_batch_managed(settings, callbacks, observer, ops):
             _set_registration_stage(STAGE_LEASE_ACQUIRE)
             try:
                 begin_registration_slot(slot_index=slot_index, attempt_index=attempt_index, worker_key=threading.current_thread().name, log=callbacks.log, cancel_callback=callbacks.cancelled)
-                _preflight_cloudmail_after_lease(callbacks)
+                _preflight_mail_after_lease(callbacks, ops)
                 _set_registration_stage(STAGE_BROWSER_START)
                 if first_browser_start or ops.browser_missing():
                     ops.start_browser(); callbacks.log("[*] 浏览器已启动"); first_browser_start = False

--- a/registration_parallel.py
+++ b/registration_parallel.py
@@ -122,6 +122,15 @@ def run_parallel_batch(count, callbacks, observer, runtime_namespace, accounts_o
 
         worker_callbacks = RegistrationCallbacks(log=worker_log, cancelled=combined_cancelled)
 
+        def preflight_mail():
+            if str(mail_module.get_email_provider() or "").strip().lower() != "cloudmail":
+                return True
+            return mail_module.cloudmail_preflight(
+                log_callback=worker_log,
+                cancel_callback=combined_cancelled,
+                defer_until_slot=False,
+            )
+
         def save_mail(email, token):
             with io_lock:
                 return runtime_namespace["_save_mail_credential"](email, token, worker_log)
@@ -193,6 +202,7 @@ def run_parallel_batch(count, callbacks, observer, runtime_namespace, accounts_o
             screen_sso=lambda sso, email: runtime_namespace["_screen_registered_sso"](
                 sso, email, worker_log
             ),
+            preflight_mail=preflight_mail,
         )
 
         def worker_observer(batch, account, output):

--- a/tests/test_cloudmail_auth.py
+++ b/tests/test_cloudmail_auth.py
@@ -1,10 +1,12 @@
-"""Regression coverage for Cloud Mail public-token authentication (issue #84)."""
+"""Regression coverage for Cloud Mail public-token authentication (issues #84/#86)."""
 
 import unittest
 from unittest.mock import Mock, patch
 
 import grok_register_ttk as app
 import mail_service
+import registration_flow
+from registration_flow import RegistrationCallbacks, RegistrationOperations
 
 
 class DummyResponse:
@@ -23,15 +25,25 @@ class DummyResponse:
             raise RuntimeError(f"HTTP {self.status_code}")
 
 
+class Cancelled(Exception):
+    pass
+
+
+class RetryNeeded(Exception):
+    pass
+
+
 class CloudMailAuthTests(unittest.TestCase):
     def setUp(self):
         self.prev_mail_config = mail_service.config
         self.prev_app_config = dict(app.config)
         mail_service.config = {
+            "email_provider": "cloudmail",
             "cloudmail_api_base": "https://mail.example.test",
             "cloudmail_public_token": "public-token-123",
             "cloudmail_domains": "example.test",
             "cloudmail_path_messages": "/api/public/emailList",
+            "proxy_mode": "direct",
         }
 
     def tearDown(self):
@@ -63,14 +75,87 @@ class CloudMailAuthTests(unittest.TestCase):
             with self.assertRaises(mail_service.CloudMailAuthError):
                 mail_service.cloudmail_get_messages("target@example.test")
 
-    def test_auth_error_is_not_retried_by_mail_polling(self):
+    def test_kv_convergence_401_then_success(self):
         auth_error = mail_service.CloudMailAuthError("bad token")
-        get_messages = Mock(side_effect=auth_error)
+        get_messages = Mock(side_effect=[auth_error, auth_error, []])
         sleeper = Mock()
 
         with patch.object(mail_service, "cloudmail_get_messages", get_messages), patch.object(
             mail_service, "raise_if_cancelled", return_value=None, create=True
         ), patch.object(mail_service, "sleep_with_cancel", sleeper, create=True):
+            messages = mail_service.cloudmail_wait_for_auth(
+                "target@example.test",
+                timeout=70,
+            )
+
+        self.assertEqual(messages, [])
+        self.assertEqual(get_messages.call_count, 3)
+        self.assertGreaterEqual(sleeper.call_count, 2)
+
+    def test_persistent_401_fails_deterministically(self):
+        auth_error = mail_service.CloudMailAuthError("bad token")
+        get_messages = Mock(side_effect=auth_error)
+
+        with patch.object(mail_service, "cloudmail_get_messages", get_messages), patch.object(
+            mail_service, "raise_if_cancelled", return_value=None, create=True
+        ), patch.object(mail_service, "sleep_with_cancel", return_value=None, create=True):
+            with self.assertRaisesRegex(
+                mail_service.CloudMailAuthError,
+                "持续验证失败",
+            ) as caught:
+                mail_service.cloudmail_wait_for_auth(
+                    "target@example.test",
+                    timeout=1,
+                )
+
+        self.assertEqual(get_messages.call_count, 2)
+        message = str(caught.exception)
+        self.assertIn("token_fp=", message)
+        self.assertIn("host=mail.example.test", message)
+        self.assertNotIn("public-token-123", message)
+
+    def test_mail_polling_allows_one_auth_convergence_window(self):
+        auth_error = mail_service.CloudMailAuthError("bad token")
+        message = {
+            "emailId": 1,
+            "toEmail": "target@example.test",
+            "subject": "123-ABC xAI",
+            "text": "verification code: 123-ABC",
+        }
+        get_messages = Mock(side_effect=auth_error)
+        recover = Mock(return_value=[message])
+
+        with patch.object(mail_service, "cloudmail_get_messages", get_messages), patch.object(
+            mail_service, "cloudmail_wait_for_auth", recover
+        ), patch.object(mail_service, "raise_if_cancelled", return_value=None, create=True):
+            code = mail_service.cloudmail_get_oai_code(
+                "unused",
+                "target@example.test",
+                timeout=180,
+                poll_interval=3,
+            )
+
+        self.assertEqual(code, "123-ABC")
+        self.assertEqual(get_messages.call_count, 1)
+        recover.assert_called_once()
+        self.assertTrue(recover.call_args.kwargs["initial_failure"])
+        self.assertLessEqual(
+            recover.call_args.kwargs["timeout"],
+            mail_service.CLOUDMAIL_AUTH_CONVERGENCE_SECONDS,
+        )
+
+    def test_persistent_auth_error_during_mail_polling_is_not_infinite(self):
+        auth_error = mail_service.CloudMailAuthError("bad token")
+        persistent = mail_service.CloudMailAuthError("持续验证失败")
+        get_messages = Mock(side_effect=auth_error)
+        recover = Mock(side_effect=persistent)
+        sleeper = Mock()
+
+        with patch.object(mail_service, "cloudmail_get_messages", get_messages), patch.object(
+            mail_service, "cloudmail_wait_for_auth", recover
+        ), patch.object(mail_service, "raise_if_cancelled", return_value=None, create=True), patch.object(
+            mail_service, "sleep_with_cancel", sleeper, create=True
+        ):
             with self.assertRaises(mail_service.CloudMailAuthError):
                 mail_service.cloudmail_get_oai_code(
                     "unused",
@@ -80,31 +165,95 @@ class CloudMailAuthTests(unittest.TestCase):
                 )
 
         self.assertEqual(get_messages.call_count, 1)
+        recover.assert_called_once()
         sleeper.assert_not_called()
 
-    def test_preflight_propagates_auth_failure(self):
-        auth_error = mail_service.CloudMailAuthError("bad token")
-        with patch.object(mail_service, "cloudmail_get_messages", side_effect=auth_error):
-            with self.assertRaises(mail_service.CloudMailAuthError):
-                mail_service.cloudmail_preflight()
+    def test_early_preflight_is_deferred_until_registration_slot(self):
+        wait = Mock(return_value=[])
+        logs = []
+        with patch.object(mail_service, "cloudmail_wait_for_auth", wait):
+            result = mail_service.cloudmail_preflight(log_callback=logs.append)
 
-    def test_registration_entry_runs_cloudmail_preflight_before_batch(self):
-        app.config["email_provider"] = "cloudmail"
-        auth_error = mail_service.CloudMailAuthError("bad token")
+        self.assertIsNone(result)
+        wait.assert_not_called()
+        self.assertTrue(any("延后" in line for line in logs))
 
-        with patch.object(app, "_bind_mail_service", return_value=None), patch.object(
-            app._mail_service, "cloudmail_preflight", side_effect=auth_error
-        ) as preflight:
-            with self.assertRaises(mail_service.CloudMailAuthError):
-                app.run_registration_common(
-                    count=1,
-                    log_callback=lambda _message: None,
-                    cancel_callback=lambda: False,
-                    accounts_output_file="unused.txt",
-                    observer=lambda *_args: None,
+    def test_slot_preflight_uses_convergence_helper(self):
+        wait = Mock(return_value=[])
+        with patch.object(mail_service, "cloudmail_wait_for_auth", wait):
+            self.assertTrue(
+                mail_service.cloudmail_preflight(
+                    defer_until_slot=False,
+                    auth_timeout=70,
                 )
+            )
 
-        preflight.assert_called_once()
+        wait.assert_called_once()
+        self.assertEqual(wait.call_args.kwargs["timeout"], 70)
+
+    def test_preflight_happens_after_lease_and_before_browser(self):
+        app.config["email_provider"] = "cloudmail"
+        events = []
+
+        def begin_slot(**_kwargs):
+            events.append("lease")
+
+        def preflight(**kwargs):
+            self.assertFalse(kwargs["defer_until_slot"])
+            events.append("preflight")
+            return True
+
+        operations = RegistrationOperations(
+            start_browser=lambda: events.append("browser"),
+            restart_browser=lambda: events.append("restart"),
+            browser_missing=lambda: True,
+            open_signup_page=lambda: None,
+            fill_email_and_submit=lambda: ("target@example.test", "mail-token"),
+            save_mail_credential=lambda *_args: True,
+            fill_code_and_submit=lambda *_args: "123-ABC",
+            fill_profile_and_submit=lambda: {
+                "given_name": "Test",
+                "family_name": "User",
+                "password": "pw",
+            },
+            wait_for_sso_cookie=lambda: "sso-token",
+            enable_nsfw=lambda _sso: (True, "ok"),
+            persist_account_line=lambda *_args: None,
+            queue_unsaved_result=lambda *_args: True,
+            add_tokens=lambda *_args: {},
+            export_cpa=lambda *_args: {"ok": False, "skipped": True},
+            cleanup=lambda _reason: None,
+            sleep=lambda _seconds: None,
+            cancelled_exception=Cancelled,
+            retry_exception=RetryNeeded,
+        )
+        callbacks = RegistrationCallbacks(log=lambda _message: None, cancelled=lambda: False)
+
+        with patch.object(registration_flow, "begin_registration_slot", side_effect=begin_slot), patch.object(
+            registration_flow, "end_registration_slot", return_value=None
+        ), patch.object(registration_flow, "current_proxy_lease", return_value=None), patch.object(
+            mail_service, "cloudmail_preflight", side_effect=preflight
+        ):
+            result = registration_flow.run_batch(
+                1,
+                callbacks,
+                lambda *_args: None,
+                operations,
+                enable_nsfw=False,
+            )
+
+        self.assertEqual(result.success_count, 1)
+        self.assertLess(events.index("lease"), events.index("preflight"))
+        self.assertLess(events.index("preflight"), events.index("browser"))
+
+    def test_token_warning_does_not_rewrite_auth_scheme(self):
+        mail_service.config["cloudmail_public_token"] = "Bearer public-token-123"
+        warnings = mail_service._cloudmail_token_warnings()
+        self.assertTrue(any("Bearer" in line for line in warnings))
+        self.assertEqual(
+            mail_service.cloudmail_build_headers()["Authorization"],
+            "Bearer public-token-123",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cloudmail_auth.py
+++ b/tests/test_cloudmail_auth.py
@@ -1,11 +1,13 @@
 """Regression coverage for Cloud Mail public-token authentication (issues #84/#86)."""
 
+from pathlib import Path
 import unittest
 from unittest.mock import Mock, patch
 
 import grok_register_ttk as app
 import mail_service
 import registration_flow
+import registration_parallel
 from registration_flow import RegistrationCallbacks, RegistrationOperations
 
 
@@ -191,15 +193,14 @@ class CloudMailAuthTests(unittest.TestCase):
         wait.assert_called_once()
         self.assertEqual(wait.call_args.kwargs["timeout"], 70)
 
-    def test_preflight_happens_after_lease_and_before_browser(self):
+    def test_injected_preflight_happens_after_lease_and_before_browser(self):
         app.config["email_provider"] = "cloudmail"
         events = []
 
         def begin_slot(**_kwargs):
             events.append("lease")
 
-        def preflight(**kwargs):
-            self.assertFalse(kwargs["defer_until_slot"])
+        def injected_preflight():
             events.append("preflight")
             return True
 
@@ -226,13 +227,15 @@ class CloudMailAuthTests(unittest.TestCase):
             sleep=lambda _seconds: None,
             cancelled_exception=Cancelled,
             retry_exception=RetryNeeded,
+            preflight_mail=injected_preflight,
         )
         callbacks = RegistrationCallbacks(log=lambda _message: None, cancelled=lambda: False)
+        global_preflight = Mock(side_effect=AssertionError("global mail preflight must not run"))
 
         with patch.object(registration_flow, "begin_registration_slot", side_effect=begin_slot), patch.object(
             registration_flow, "end_registration_slot", return_value=None
         ), patch.object(registration_flow, "current_proxy_lease", return_value=None), patch.object(
-            mail_service, "cloudmail_preflight", side_effect=preflight
+            mail_service, "cloudmail_preflight", global_preflight
         ):
             result = registration_flow.run_batch(
                 1,
@@ -243,8 +246,15 @@ class CloudMailAuthTests(unittest.TestCase):
             )
 
         self.assertEqual(result.success_count, 1)
+        global_preflight.assert_not_called()
         self.assertLess(events.index("lease"), events.index("preflight"))
         self.assertLess(events.index("preflight"), events.index("browser"))
+
+    def test_parallel_workers_bind_preflight_to_isolated_mail_module(self):
+        source = Path(registration_parallel.__file__).read_text(encoding="utf-8")
+        self.assertIn("mail_module.cloudmail_preflight(", source)
+        self.assertIn("preflight_mail=preflight_mail", source)
+        self.assertNotIn("preflight_mail=mail_service.cloudmail_preflight", source)
 
     def test_token_warning_does_not_rewrite_auth_scheme(self):
         mail_service.config["cloudmail_public_token"] = "Bearer public-token-123"


### PR DESCRIPTION
Fixes #86.

This change keeps the official Cloud Mail protocol unchanged and fixes the client-side handling around Workers KV-backed public-token validation:

- keep raw `Authorization: <public token>` with no Bearer or alternate-auth fallback
- retry only Cloud Mail public-token 401s inside a bounded ~70s KV convergence window
- keep the same network/proxy context during convergence; do not rotate proxy or regenerate tokens
- run the real Cloud Mail preflight after the registration slot / Proxy Lease is established and before browser startup
- inject preflight through `RegistrationOperations.preflight_mail`; parallel workers bind their own isolated `mail_service` module
- allow one bounded auth-recovery window during mailbox polling if a later request lands on stale KV state
- add persistent-mismatch diagnostics using API host/path, token length, short SHA-256 fingerprint, and network label without logging the full token
- update README guidance and focused #84/#86 regression coverage

Intentionally unchanged: Cloud Mail API paths/payload format, browser/Turnstile behavior, proxy-pool selection rules, account retry boundaries, CPA, and dependencies.