### PR TITLE
Add GitHub Actions CI test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,49 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-web.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-web.txt pytest
+
+      - name: Compile Python sources
+        run: python -m compileall -q .
+
+      - name: Run test suite
+        run: python -m pytest -q

--- a/tests/test_drission_concurrency_regression.py
+++ b/tests/test_drission_concurrency_regression.py
@@ -100,6 +100,9 @@ class DrissionConcurrencyRegressionTests(unittest.TestCase):
             def bind_runtime(self, _namespace):
                 return None
 
+            def get_email_provider(self):
+                return "duckmail"
+
         class FakeBrowser:
             def __init__(self, worker_id):
                 self.worker_id = worker_id

--- a/tests/test_optional_multithread.py
+++ b/tests/test_optional_multithread.py
@@ -89,6 +89,8 @@ class OptionalMultithreadTests(unittest.TestCase):
             _OWN_NAMES = set()
             def bind_runtime(self, _namespace):
                 return None
+            def get_email_provider(self):
+                return "duckmail"
 
         class FakeBrowser:
             def __init__(self, worker_number):


### PR DESCRIPTION
Adds a lightweight GitHub Actions CI workflow for the repository.

- runs on pushes to `main`, pull requests targeting `main`, and manual dispatch
- tests Python 3.9 and 3.13
- installs full core + WebUI dependencies and `pytest`
- compiles Python sources before tests
- runs the complete pytest suite
- uses read-only repository permissions and pip caching

This gives future fixes a real CI result before merge.